### PR TITLE
[UUID 2/8] UUID ingest and segment storage

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
@@ -164,6 +164,18 @@ public class GenericRowDeserializer {
               multiValue[j] = new String(stringBytes, UTF_8);
             }
             break;
+          case BYTES:
+            // Used by MV UUID (storedType=BYTES). Mirrors the writer in GenericRowSerializer:
+            // each element is length-prefixed.
+            for (int j = 0; j < numValues; j++) {
+              int numBytes = _dataBuffer.getInt(offset);
+              offset += Integer.BYTES;
+              byte[] elementBytes = new byte[numBytes];
+              _dataBuffer.copyTo(offset, elementBytes);
+              offset += numBytes;
+              multiValue[j] = elementBytes;
+            }
+            break;
           default:
             throw new IllegalStateException("Unsupported MV stored type: " + _storedTypes[i]);
         }
@@ -359,6 +371,26 @@ public class GenericRowDeserializer {
               byte[] stringBytes2 = new byte[numBytes2];
               _dataBuffer.copyTo(offset2, stringBytes2);
               int result = new String(stringBytes1, UTF_8).compareTo(new String(stringBytes2, UTF_8));
+              if (result != 0) {
+                return result;
+              }
+              offset1 += numBytes1;
+              offset2 += numBytes2;
+            }
+            break;
+          case BYTES:
+            // Used by MV UUID (storedType=BYTES). Element-wise unsigned byte compare matches the SV BYTES
+            // ordering above.
+            for (int j = 0; j < numValues; j++) {
+              int numBytes1 = _dataBuffer.getInt(offset1);
+              offset1 += Integer.BYTES;
+              byte[] elementBytes1 = new byte[numBytes1];
+              _dataBuffer.copyTo(offset1, elementBytes1);
+              int numBytes2 = _dataBuffer.getInt(offset2);
+              offset2 += Integer.BYTES;
+              byte[] elementBytes2 = new byte[numBytes2];
+              _dataBuffer.copyTo(offset2, elementBytes2);
+              int result = ByteArray.compare(elementBytes1, elementBytes2);
               if (result != 0) {
                 return result;
               }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
@@ -148,6 +148,14 @@ public class GenericRowSerializer {
             }
             _objectBytes[i] = stringBytesArray;
             break;
+          case BYTES:
+            // Used by MV UUID (storedType=BYTES) — also supports any MV BYTES column going through the
+            // SegmentProcessorFramework. Each element is length-prefixed like SV BYTES.
+            numBytes += Integer.BYTES * numValues;
+            for (Object element : multiValue) {
+              numBytes += ((byte[]) element).length;
+            }
+            break;
           default:
             throw new IllegalStateException("Unsupported MV stored type: " + _storedTypes[i]);
         }
@@ -238,6 +246,13 @@ public class GenericRowSerializer {
             for (byte[] stringBytes : stringBytesArray) {
               byteBuffer.putInt(stringBytes.length);
               byteBuffer.put(stringBytes);
+            }
+            break;
+          case BYTES:
+            for (Object element : multiValue) {
+              byte[] elementBytes = (byte[]) element;
+              byteBuffer.putInt(elementBytes.length);
+              byteBuffer.put(elementBytes);
             }
             break;
           default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -119,7 +119,7 @@ public class SegmentMapper {
         schema.isEnableColumnBasedNullHandling() || tableConfig.getIndexingConfig().isNullHandlingEnabled();
     _transformPipeline = transformPipeline;
     _timeHandler = TimeHandlerFactory.getTimeHandler(processorConfig);
-    _partitioners = PartitionerFactory.getPartitioners(processorConfig.getPartitionerConfigs());
+    _partitioners = PartitionerFactory.getPartitioners(processorConfig.getPartitionerConfigs(), schema);
     // Time partition + partition from partitioners
     _partitionsBuffer = new String[_partitioners.length + 1];
     _throttledLogger = new ThrottledLogger(LOGGER, tableConfig.getIngestionConfig());

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
@@ -19,11 +19,14 @@
 package org.apache.pinot.core.util;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
@@ -32,6 +35,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.ingestion.segment.writer.SegmentWriter;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -57,18 +61,48 @@ public final class SegmentProcessorAvroUtils {
    */
   public static GenericData.Record convertGenericRowToAvroRecord(GenericRow genericRow,
       GenericData.Record reusableRecord, Set<String> fields) {
+    Schema avroSchema = reusableRecord.getSchema();
     for (String field : fields) {
       Object value = genericRow.getValue(field);
       if (value instanceof Object[]) {
-        reusableRecord.put(field, Arrays.asList((Object[]) value));
+        Schema.Field avroField = avroSchema.getField(field);
+        if (avroField != null && isUuidArrayLogicalType(avroField.schema())) {
+          // MV UUID columns are emitted with an Avro array<string{logicalType:uuid}> schema; convert each
+          // 16-byte element to its canonical UUID string so GenericDatumWriter accepts the record.
+          Object[] elements = (Object[]) value;
+          List<Object> converted = new ArrayList<>(elements.length);
+          for (Object element : elements) {
+            converted.add(element instanceof byte[] ? UuidUtils.toString((byte[]) element) : element);
+          }
+          reusableRecord.put(field, converted);
+        } else {
+          reusableRecord.put(field, Arrays.asList((Object[]) value));
+        }
       } else {
         if (value instanceof byte[]) {
-          value = ByteBuffer.wrap((byte[]) value);
+          // UUID columns are emitted with an Avro string{logicalType:uuid} schema (Avro 1.x only allows the
+          // uuid logical type on string), so the 16-byte canonical form must be rendered as a canonical
+          // UUID string here. Plain BYTES columns continue to be wrapped as ByteBuffer.
+          Schema.Field avroField = avroSchema.getField(field);
+          if (avroField != null && isUuidLogicalType(avroField.schema())) {
+            value = UuidUtils.toString((byte[]) value);
+          } else {
+            value = ByteBuffer.wrap((byte[]) value);
+          }
         }
         reusableRecord.put(field, value);
       }
     }
     return reusableRecord;
+  }
+
+  private static boolean isUuidLogicalType(Schema schema) {
+    LogicalType logicalType = LogicalTypes.fromSchemaIgnoreInvalid(schema);
+    return logicalType != null && "uuid".equals(logicalType.getName());
+  }
+
+  private static boolean isUuidArrayLogicalType(Schema schema) {
+    return schema.getType() == Schema.Type.ARRAY && isUuidLogicalType(schema.getElementType());
   }
 
   /**
@@ -82,6 +116,19 @@ public final class SegmentProcessorAvroUtils {
         .collect(Collectors.toList());
     for (FieldSpec fieldSpec : orderedFieldSpecs) {
       String name = fieldSpec.getName();
+      // Emit UUID columns as Avro string{logicalType:uuid} (matching AvroUtils.getAvroSchemaFromPinotSchema)
+      // so the runtime byte[] → canonical-string conversion in convertGenericRowToAvroRecord lines up with
+      // the field schema. Without this branch SV UUID would fall through to BYTES (losing UUID semantics) and
+      // MV UUID would throw at this point (MV switch below has no BYTES case).
+      if (fieldSpec.getDataType() == DataType.UUID) {
+        Schema uuidSchema = LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING));
+        if (fieldSpec.isSingleValueField()) {
+          fieldAssembler = fieldAssembler.name(name).type(uuidSchema).noDefault();
+        } else {
+          fieldAssembler = fieldAssembler.name(name).type().array().items(uuidSchema).noDefault();
+        }
+        continue;
+      }
       DataType storedType = fieldSpec.getDataType().getStoredType();
       if (fieldSpec.isSingleValueField()) {
         switch (storedType) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableIndexingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableIndexingTest.java
@@ -159,7 +159,10 @@ public class TableIndexingTest {
   protected void createSchemas() {
     for (DataType type : DataType.values()) {
       if (type == DataType.UNKNOWN || type == DataType.LIST || type == DataType.MAP || type == DataType.STRUCT
-          || type == DataType.OPEN_STRUCT) {
+          || type == DataType.OPEN_STRUCT || type == DataType.UUID) {
+        // UUID is excluded because this static expectation matrix (TableIndexingTest.csv) has no UUID rows.
+        // UUID-specific index behavior (inverted, bloom, range, dictionary/no-dictionary, SV and MV) is covered by
+        // the dedicated UUID tests (UuidTypeTest, UuidTypeRealtimeTest and the UUID segment/index unit tests).
         continue;
       }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerDeTest.java
@@ -55,6 +55,10 @@ public class GenericRowSerDeTest {
         new DimensionFieldSpec("floatMV", DataType.FLOAT, false),
         new DimensionFieldSpec("doubleMV", DataType.DOUBLE, false),
         new DimensionFieldSpec("stringMV", DataType.STRING, false),
+        // MV BYTES is the storage shape for MV UUID columns; the GenericRow serializer/deserializer must
+        // round-trip these (used by every SegmentProcessorFramework minion task — MergeRollup,
+        // RealtimeToOffline, UpsertCompactMerge).
+        new DimensionFieldSpec("bytesMV", DataType.BYTES, false),
         new DimensionFieldSpec("nullMV", DataType.LONG, false));
 
     _row = new GenericRow();
@@ -78,6 +82,7 @@ public class GenericRowSerDeTest {
     _row.putValue("floatMV", new Object[]{123.0f, 456.0f});
     _row.putValue("doubleMV", new Object[]{123.0, 456.0});
     _row.putValue("stringMV", new Object[]{"123", "456"});
+    _row.putValue("bytesMV", new Object[]{new byte[]{1, 2, 3}, new byte[]{4, 5, 6, 7}, new byte[]{}});
     _row.putDefaultNullValue("nullMV", new Object[]{Long.MIN_VALUE});
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SegmentProcessorAvroUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SegmentProcessorAvroUtilsTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class SegmentProcessorAvroUtilsTest {
+
+  /**
+   * Regression test: UUID columns are exported with an Avro {@code string{logicalType:uuid}} schema, so the
+   * 16-byte canonical form held internally must be converted to a canonical UUID string at write time. Wrapping
+   * it as a ByteBuffer (the default for plain BYTES columns) would be rejected by GenericDatumWriter against a
+   * STRING-typed schema.
+   */
+  @Test
+  public void testConvertGenericRowToAvroRecordRendersUuidBytesAsCanonicalString() {
+    Schema uuidSchema = LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING));
+    Schema bytesSchema = Schema.create(Schema.Type.BYTES);
+    Schema recordSchema = SchemaBuilder.record("record").fields()
+        .name("uuidCol").type(uuidSchema).noDefault()
+        .name("bytesCol").type(bytesSchema).noDefault()
+        .endRecord();
+
+    String canonical = "12345678-1234-1234-1234-1234567890ab";
+    byte[] uuidBytes = UuidUtils.toBytes(canonical);
+    byte[] rawBytes = new byte[]{1, 2, 3, 4};
+
+    GenericRow row = new GenericRow();
+    row.putValue("uuidCol", uuidBytes);
+    row.putValue("bytesCol", rawBytes);
+
+    GenericData.Record reusableRecord = new GenericData.Record(recordSchema);
+    SegmentProcessorAvroUtils.convertGenericRowToAvroRecord(row, reusableRecord);
+
+    assertEquals(reusableRecord.get("uuidCol"), canonical,
+        "UUID byte[] must be converted to canonical UUID string for string{logicalType:uuid} fields");
+    assertEquals(reusableRecord.get("bytesCol"), ByteBuffer.wrap(rawBytes),
+        "Plain BYTES columns must continue to be wrapped as ByteBuffer");
+  }
+
+  /**
+   * Regression: MV UUID columns are emitted as Avro {@code array<string{logicalType:uuid}>}. The 16-byte
+   * canonical-form elements must be converted to canonical UUID strings, otherwise GenericDatumWriter would
+   * reject the byte[] elements against the string-typed array schema.
+   */
+  @Test
+  public void testConvertGenericRowToAvroRecordRendersMvUuidBytesAsCanonicalStrings() {
+    Schema uuidElementSchema = LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING));
+    Schema uuidArraySchema = Schema.createArray(uuidElementSchema);
+    Schema recordSchema = SchemaBuilder.record("record").fields()
+        .name("uuidArrayCol").type(uuidArraySchema).noDefault()
+        .endRecord();
+
+    String canonicalA = "12345678-1234-1234-1234-1234567890ab";
+    String canonicalB = "550e8400-e29b-41d4-a716-446655440000";
+    Object[] uuidMv = new Object[]{UuidUtils.toBytes(canonicalA), UuidUtils.toBytes(canonicalB)};
+
+    GenericRow row = new GenericRow();
+    row.putValue("uuidArrayCol", uuidMv);
+
+    GenericData.Record reusableRecord = new GenericData.Record(recordSchema);
+    SegmentProcessorAvroUtils.convertGenericRowToAvroRecord(row, reusableRecord);
+
+    Object emitted = reusableRecord.get("uuidArrayCol");
+    assertEquals(emitted instanceof List, true, "MV UUID column must be emitted as a List for Avro array schema");
+    assertEquals(emitted, Arrays.asList(canonicalA, canonicalB),
+        "MV UUID byte[] elements must each be converted to canonical UUID strings");
+  }
+
+  /**
+   * Regression: convertPinotSchemaToAvroSchema must emit SV UUID as {@code string{logicalType:uuid}} (not plain
+   * BYTES) and MV UUID as {@code array<string{logicalType:uuid}>}. Without the UUID branch, SV UUID would
+   * silently fall through to plain BYTES (losing UUID semantics in the output Avro file) and MV UUID would
+   * throw at schema-construction time because the MV switch has no BYTES case.
+   */
+  @Test
+  public void testConvertPinotSchemaToAvroSchemaEmitsUuidLogicalType() {
+    org.apache.pinot.spi.data.Schema pinotSchema = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("uuidSchema")
+        .addSingleValueDimension("uuidSv", org.apache.pinot.spi.data.FieldSpec.DataType.UUID)
+        .addMultiValueDimension("uuidMv", org.apache.pinot.spi.data.FieldSpec.DataType.UUID)
+        .build();
+
+    Schema avroSchema = SegmentProcessorAvroUtils.convertPinotSchemaToAvroSchema(pinotSchema);
+
+    Schema svFieldSchema = avroSchema.getField("uuidSv").schema();
+    assertEquals(svFieldSchema.getType(), Schema.Type.STRING, "SV UUID must be string{logicalType:uuid}");
+    assertEquals(LogicalTypes.fromSchemaIgnoreInvalid(svFieldSchema), LogicalTypes.uuid(),
+        "SV UUID must carry the uuid logical type");
+
+    Schema mvFieldSchema = avroSchema.getField("uuidMv").schema();
+    assertEquals(mvFieldSchema.getType(), Schema.Type.ARRAY, "MV UUID must be emitted as an array");
+    Schema mvElementSchema = mvFieldSchema.getElementType();
+    assertEquals(mvElementSchema.getType(), Schema.Type.STRING,
+        "MV UUID elements must be string{logicalType:uuid}");
+    assertEquals(LogicalTypes.fromSchemaIgnoreInvalid(mvElementSchema), LogicalTypes.uuid(),
+        "MV UUID elements must carry the uuid logical type");
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroIngestionSchemaValidator.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroIngestionSchemaValidator.java
@@ -139,7 +139,7 @@ public class AvroIngestionSchemaValidator implements IngestionSchemaValidator {
         if (fieldSpec.getDataType() != dataTypeForSVColumn) {
           _dataTypeMismatch.addMismatchReason(String
               .format("The Pinot column: (%s: %s) doesn't match with the column (%s: %s) in input %s schema.",
-                  columnName, fieldSpec.getDataType().name(), avroColumnName, avroColumnType.name(),
+                  columnName, fieldSpec.getDataType().name(), avroColumnName, dataTypeForSVColumn.name(),
                   getInputSchemaType()));
         }
       } else {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
@@ -20,14 +20,21 @@ package org.apache.pinot.plugin.inputformat.avro;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /// Stateless helpers for mapping between Avro schema shapes and Pinot's [DataType] / Avro JSON schema representations.
 public class AvroSchemaUtil {
+  // Avro logical-type name for UUID (see org.apache.avro.LogicalTypes). Value-level logical-type conversion lives
+  // in AvroRecordExtractor; this class only deals with schema-shape mapping.
+  private static final String UUID = "uuid";
+
   private AvroSchemaUtil() {
   }
 
@@ -60,7 +67,31 @@ public class AvroSchemaUtil {
     }
   }
 
-  /// Returns whether the given Avro type is a primitive type.
+  /**
+   * Returns the Pinot data type associated with the given Avro schema, including logical types.
+   *
+   * <p>Recognizes the UUID logical type on both STRING-backed schemas (Avro spec §logical-types.uuid) and FIXED(16)
+   * schemas (used by some producers including Confluent's fixed-uuid mode). Both forms arrive at
+   * {@link org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractor} as either a {@link java.util.UUID} (for
+   * STRING-backed logical UUIDs) or a 16-byte {@code byte[]} (for FIXED-backed ones), and both are accepted by
+   * {@link org.apache.pinot.spi.utils.UuidUtils#toBytes(Object)}.
+   */
+  public static DataType valueOf(Schema schema) {
+    LogicalType logicalType = LogicalTypes.fromSchemaIgnoreInvalid(schema);
+    if (logicalType != null && UUID.equals(logicalType.getName())) {
+      if (schema.getType() == Schema.Type.STRING) {
+        return DataType.UUID;
+      }
+      if (schema.getType() == Schema.Type.FIXED && schema.getFixedSize() == UuidUtils.UUID_NUM_BYTES) {
+        return DataType.UUID;
+      }
+    }
+    return valueOf(schema.getType());
+  }
+
+  /**
+   * @return if the given avro type is a primitive type.
+   */
   public static boolean isPrimitiveType(Schema.Type avroType) {
     switch (avroType) {
       case INT:
@@ -79,7 +110,8 @@ public class AvroSchemaUtil {
   public static ObjectNode toAvroSchemaJsonObject(FieldSpec fieldSpec) {
     ObjectNode jsonSchema = JsonUtils.newObjectNode();
     jsonSchema.put("name", fieldSpec.getName());
-    switch (fieldSpec.getDataType().getStoredType()) {
+    DataType dataType = fieldSpec.getDataType();
+    switch (dataType.getStoredType()) {
       case INT:
         jsonSchema.set("type", convertStringsToJsonArray("null", "int"));
         return jsonSchema;
@@ -97,7 +129,21 @@ public class AvroSchemaUtil {
         jsonSchema.set("type", convertStringsToJsonArray("null", "string"));
         return jsonSchema;
       case BYTES:
-        jsonSchema.set("type", convertStringsToJsonArray("null", "bytes"));
+        if (dataType == DataType.UUID) {
+          ObjectNode uuidType = JsonUtils.newObjectNode();
+          uuidType.put("type", "string");
+          uuidType.put("logicalType", UUID);
+          if (fieldSpec.isSingleValueField()) {
+            jsonSchema.set("type", convertToJsonArray("null", uuidType));
+          } else {
+            ObjectNode uuidArrayType = JsonUtils.newObjectNode();
+            uuidArrayType.put("type", "array");
+            uuidArrayType.set("items", uuidType);
+            jsonSchema.set("type", convertToJsonArray("null", uuidArrayType));
+          }
+        } else {
+          jsonSchema.set("type", convertStringsToJsonArray("null", "bytes"));
+        }
         return jsonSchema;
       default:
         throw new UnsupportedOperationException();
@@ -109,6 +155,13 @@ public class AvroSchemaUtil {
     for (String string : strings) {
       jsonArray.add(string);
     }
+    return jsonArray;
+  }
+
+  private static ArrayNode convertToJsonArray(String string, ObjectNode objectNode) {
+    ArrayNode jsonArray = JsonUtils.newArrayNode();
+    jsonArray.add(string);
+    jsonArray.add(objectNode);
     return jsonArray;
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileStream;
@@ -160,6 +161,16 @@ public class AvroUtils {
     SchemaBuilder.FieldAssembler<org.apache.avro.Schema> fieldAssembler = SchemaBuilder.record("record").fields();
 
     for (FieldSpec fieldSpec : pinotSchema.getAllFieldSpecs()) {
+      if (fieldSpec.getDataType() == DataType.UUID) {
+        org.apache.avro.Schema uuidSchema = LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(
+            org.apache.avro.Schema.Type.STRING));
+        if (fieldSpec.isSingleValueField()) {
+          fieldAssembler = fieldAssembler.name(fieldSpec.getName()).type(uuidSchema).noDefault();
+        } else {
+          fieldAssembler = fieldAssembler.name(fieldSpec.getName()).type().array().items(uuidSchema).noDefault();
+        }
+        continue;
+      }
       DataType storedType = fieldSpec.getDataType().getStoredType();
       if (fieldSpec.isSingleValueField()) {
         switch (storedType) {
@@ -244,12 +255,13 @@ public class AvroUtils {
   public static DataType extractFieldDataType(Field field) {
     try {
       org.apache.avro.Schema fieldSchema = extractSupportedSchema(field.schema());
-      org.apache.avro.Schema.Type fieldType = fieldSchema.getType();
-      if (fieldType == org.apache.avro.Schema.Type.ARRAY) {
-        return AvroSchemaUtil.valueOf(extractSupportedSchema(fieldSchema.getElementType()).getType());
+      if (fieldSchema.getType() == org.apache.avro.Schema.Type.ARRAY) {
+        return AvroSchemaUtil.valueOf(extractSupportedSchema(fieldSchema.getElementType()));
       } else {
-        return AvroSchemaUtil.valueOf(fieldType);
+        return AvroSchemaUtil.valueOf(fieldSchema);
       }
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while extracting data type from field: " + field.name(), e);
     }
@@ -323,16 +335,17 @@ public class AvroUtils {
           extractSchemaWithComplexTypeHandling(elementType, fieldsToUnnest, delimiter, path, pinotSchema, fieldTypeMap,
               timeUnit, collectionNotUnnestedToJson);
         } else if (collectionNotUnnestedToJson == ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE
-            && AvroSchemaUtil.isPrimitiveType(elementType.getType())) {
-          addFieldToPinotSchema(pinotSchema, AvroSchemaUtil.valueOf(elementType.getType()), path, false, fieldTypeMap,
-              timeUnit);
+            && (AvroSchemaUtil.isPrimitiveType(elementType.getType())
+                || AvroSchemaUtil.valueOf(elementType) == DataType.UUID)) {
+          DataType elementDataType = AvroSchemaUtil.valueOf(elementType);
+          addFieldToPinotSchema(pinotSchema, elementDataType, path, false, fieldTypeMap, timeUnit);
         } else if (shallConvertToJson(collectionNotUnnestedToJson, elementType)) {
           addFieldToPinotSchema(pinotSchema, DataType.STRING, path, true, fieldTypeMap, timeUnit);
         }
         // do not include the node for other cases
         break;
       default:
-        DataType dataType = AvroSchemaUtil.valueOf(fieldType);
+        DataType dataType = AvroSchemaUtil.valueOf(fieldSchema);
         addFieldToPinotSchema(pinotSchema, dataType, path, true, fieldTypeMap, timeUnit);
         break;
     }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.avro;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.avro.Schema;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/// Tests for the schema-shape mapping helpers in [AvroSchemaUtil]. Value-level logical-type conversion is owned by
+/// `AvroRecordExtractor` and tested there.
+public class AvroSchemaUtilTest {
+
+  @Test
+  public void testValueOfUuidStringLogicalType() {
+    String schemaStr = "{\"type\":\"record\",\"name\":\"r\",\"fields\":[{\"name\":\"id\","
+        + "\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}}]}";
+    Schema schema = new Schema.Parser().parse(schemaStr);
+    Assert.assertEquals(AvroSchemaUtil.valueOf(schema.getField("id").schema()),
+        FieldSpec.DataType.UUID, "STRING logicalType:uuid should map to UUID");
+  }
+
+  @Test
+  public void testValueOfUuidFixed16LogicalType() {
+    // FIXED(16) + logicalType:uuid — produced by Confluent fixed-uuid mode and Parquet uuid
+    String schemaStr = "{\"type\":\"record\",\"name\":\"r\",\"fields\":[{\"name\":\"id\","
+        + "\"type\":{\"type\":\"fixed\",\"name\":\"uuid_fixed\",\"size\":16,\"logicalType\":\"uuid\"}}]}";
+    Schema schema = new Schema.Parser().parse(schemaStr);
+    Assert.assertEquals(AvroSchemaUtil.valueOf(schema.getField("id").schema()),
+        FieldSpec.DataType.UUID, "FIXED(16) logicalType:uuid should map to UUID");
+  }
+
+  @Test
+  public void testValueOfFixed16WithoutLogicalTypeIsBytes() {
+    // FIXED(16) without logicalType should stay as BYTES
+    String schemaStr = "{\"type\":\"record\",\"name\":\"r\",\"fields\":[{\"name\":\"raw\","
+        + "\"type\":{\"type\":\"fixed\",\"name\":\"raw16\",\"size\":16}}]}";
+    Schema schema = new Schema.Parser().parse(schemaStr);
+    Assert.assertEquals(AvroSchemaUtil.valueOf(schema.getField("raw").schema()),
+        FieldSpec.DataType.BYTES, "FIXED(16) without logicalType:uuid should stay BYTES");
+  }
+
+  @Test
+  public void testValueOfFixedWrongSizeWithUuidLogicalTypeIsBytes() {
+    // FIXED of non-16 size with logicalType:uuid should not map to UUID
+    String schemaStr = "{\"type\":\"record\",\"name\":\"r\",\"fields\":[{\"name\":\"id\","
+        + "\"type\":{\"type\":\"fixed\",\"name\":\"uuid32\",\"size\":32,\"logicalType\":\"uuid\"}}]}";
+    Schema schema = new Schema.Parser().parse(schemaStr);
+    Assert.assertEquals(AvroSchemaUtil.valueOf(schema.getField("id").schema()),
+        FieldSpec.DataType.BYTES, "FIXED(32) with logicalType:uuid should stay BYTES");
+  }
+
+  @Test
+  public void testToAvroSchemaJsonObjectForUuid() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("uuidCol", FieldSpec.DataType.UUID, true);
+
+    JsonNode jsonNode = AvroSchemaUtil.toAvroSchemaJsonObject(fieldSpec);
+
+    Assert.assertEquals(jsonNode.get("name").asText(), "uuidCol");
+    Assert.assertEquals(jsonNode.get("type").get(0).asText(), "null");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("type").asText(), "string");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("logicalType").asText(), "uuid");
+  }
+
+  @Test
+  public void testToAvroSchemaJsonObjectForUuidArray() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("uuidCol", FieldSpec.DataType.UUID, false);
+
+    JsonNode jsonNode = AvroSchemaUtil.toAvroSchemaJsonObject(fieldSpec);
+
+    Assert.assertEquals(jsonNode.get("name").asText(), "uuidCol");
+    Assert.assertEquals(jsonNode.get("type").get(0).asText(), "null");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("type").asText(), "array");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("items").get("type").asText(), "string");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("items").get("logicalType").asText(), "uuid");
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroUtilsTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroUtilsTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.avro.LogicalTypes;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -130,5 +131,59 @@ public class AvroUtilsTest {
             .addSingleValueDimension("d1", DataType.STRING).addMetric("m1", DataType.INT)
             .addDateTime("hoursSinceEpoch", DataType.LONG, "EPOCH|HOURS", "1:HOURS").build();
     assertEquals(inferredPinotSchema, expectedSchema);
+  }
+
+  @Test
+  public void testGetPinotSchemaFromAvroSchemaWithUuidLogicalType() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("uuidRecord", null, null, false);
+    org.apache.avro.Schema uuidSchema =
+        LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+    avroSchema.setFields(Lists.newArrayList(
+        new org.apache.avro.Schema.Field("uuidCol", uuidSchema, null, null)
+    ));
+
+    Schema inferredPinotSchema = AvroUtils.getPinotSchemaFromAvroSchema(avroSchema, null, null);
+
+    Schema expectedSchema =
+        new Schema.SchemaBuilder().addSingleValueDimension("uuidCol", DataType.UUID).build();
+    assertEquals(inferredPinotSchema, expectedSchema);
+  }
+
+  @Test
+  public void testGetAvroSchemaFromPinotSchemaWithUuidLogicalType() {
+    Schema pinotSchema = new Schema.SchemaBuilder().addSingleValueDimension("uuidCol", DataType.UUID).build();
+
+    org.apache.avro.Schema avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(pinotSchema);
+    org.apache.avro.Schema fieldSchema = avroSchema.getField("uuidCol").schema();
+
+    assertEquals(fieldSchema.getType(), org.apache.avro.Schema.Type.STRING);
+    assertEquals(fieldSchema.getLogicalType().getName(), "uuid");
+  }
+
+  @Test
+  public void testGetPinotSchemaFromAvroSchemaWithUuidArray() {
+    org.apache.avro.Schema uuidSchema =
+        LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("uuidArrayRecord").fields()
+        .name("uuidArray").type().array().items(uuidSchema).noDefault().endRecord();
+
+    Schema inferredPinotSchema = AvroUtils.getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, null, null,
+        new ArrayList<>(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
+
+    Schema expectedSchema =
+        new Schema.SchemaBuilder().addMultiValueDimension("uuidArray", DataType.UUID).build();
+    assertEquals(inferredPinotSchema, expectedSchema);
+  }
+
+  @Test
+  public void testGetAvroSchemaFromPinotSchemaWithMvUuid() {
+    Schema pinotSchema = new Schema.SchemaBuilder().addMultiValueDimension("uuidMv", DataType.UUID).build();
+
+    org.apache.avro.Schema avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(pinotSchema);
+    org.apache.avro.Schema fieldSchema = avroSchema.getField("uuidMv").schema();
+
+    assertEquals(fieldSchema.getType(), org.apache.avro.Schema.Type.ARRAY);
+    assertEquals(fieldSchema.getElementType().getType(), org.apache.avro.Schema.Type.STRING);
+    assertEquals(fieldSchema.getElementType().getLogicalType().getName(), "uuid");
   }
 }

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -111,6 +111,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-csv</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -123,6 +123,7 @@ import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.FixedIntArray;
 import org.apache.pinot.spi.utils.MapUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -372,16 +373,9 @@ public class MutableSegmentImpl implements MutableSegment {
       } else {
         dictionary = null;
         if (!fieldSpec.isSingleValueField()) {
-          // Raw MV columns
-          switch (storedType) {
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-              break;
-            default:
-              throw new UnsupportedOperationException(
-                  "Unsupported data type: " + dataType + " for MV no-dictionary column: " + column);
+          if (!dataType.isFixedWidth()) {
+            throw new UnsupportedOperationException(
+                "Unsupported data type: " + dataType + " for MV no-dictionary column: " + column);
           }
         }
       }
@@ -589,7 +583,7 @@ public class MutableSegmentImpl implements MutableSegment {
     // So to continue aggregating metrics for such cases, we will create dictionary even
     // if the column is part of noDictionary set from table config
     if (fieldSpec instanceof DimensionFieldSpec && isAggregateMetricsEnabled() && (dataType == STRING
-        || dataType == BYTES)) {
+        || dataType.getStoredType() == BYTES)) {
       _logger.info("Aggregate metrics is enabled. Will create dictionary in consuming segment for column {} of type {}",
           column, dataType);
       return false;
@@ -770,7 +764,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private DedupRecordInfo getDedupRecordInfo(GenericRow row) {
-    PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
+    PrimaryKey primaryKey = getPrimaryKey(row);
     // it is okay not having dedup time column if metadata ttl is not enabled
     if (_dedupTimeColumn == null) {
       return new DedupRecordInfo(primaryKey);
@@ -780,16 +774,37 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private RecordInfo getRecordInfo(GenericRow row, int docId) {
-    PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
+    PrimaryKey primaryKey = getPrimaryKey(row);
     Comparable comparisonValue = getComparisonValue(row);
     boolean deleteRecord = _deleteRecordColumn != null && BooleanUtils.toBoolean(row.getValue(_deleteRecordColumn));
     return new RecordInfo(primaryKey, docId, comparisonValue, deleteRecord);
   }
 
+  private PrimaryKey getPrimaryKey(GenericRow row) {
+    List<String> primaryKeyColumns = _schema.getPrimaryKeyColumns();
+    int numPrimaryKeyColumns = primaryKeyColumns.size();
+    Object[] values = new Object[numPrimaryKeyColumns];
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      String primaryKeyColumn = primaryKeyColumns.get(i);
+      Object value = row.getValue(primaryKeyColumn);
+      DataType dataType = _schema.getFieldSpecFor(primaryKeyColumn).getDataType();
+      values[i] = normalizePrimaryKeyValue(value, dataType);
+    }
+    return new PrimaryKey(values);
+  }
+
+  private Object normalizePrimaryKeyValue(@Nullable Object value, DataType dataType) {
+    if (dataType == DataType.UUID) {
+      return new ByteArray(UuidUtils.toBytes(value));
+    }
+    return value instanceof byte[] ? new ByteArray((byte[]) value) : value;
+  }
+
   private Comparable getComparisonValue(GenericRow row) {
     int numComparisonColumns = _upsertComparisonColumns.size();
     if (numComparisonColumns == 1) {
-      return (Comparable) row.getValue(_upsertComparisonColumns.get(0));
+      String comparisonColumn = _upsertComparisonColumns.get(0);
+      return toComparableValue(row.getValue(comparisonColumn), _schema.getFieldSpecFor(comparisonColumn).getDataType());
     }
 
     Comparable[] comparisonValues = new Comparable[numComparisonColumns];
@@ -808,9 +823,8 @@ public class MutableSegmentImpl implements MutableSegment {
         comparableIndex = i;
 
         Object comparisonValue = row.getValue(columnName);
-        Preconditions.checkState(comparisonValue instanceof Comparable,
-            "Upsert comparison column: %s must be comparable", columnName);
-        comparisonValues[i] = (Comparable) comparisonValue;
+        comparisonValues[i] =
+            toComparableValue(comparisonValue, _schema.getFieldSpecFor(columnName).getDataType(), columnName);
       }
     }
     Preconditions.checkState(comparableIndex != -1, "Documents must have exactly 1 non-null comparison column value");
@@ -957,14 +971,7 @@ public class MutableSegmentImpl implements MutableSegment {
           // Update min/max value from raw value
           // NOTE: Skip updating min/max value for aggregated metrics because the value will change over time.
           if (!isAggregateMetricsEnabled() || fieldSpec.getFieldType() != FieldSpec.FieldType.METRIC) {
-            Comparable comparable;
-            if (dataType == BYTES) {
-              comparable = new ByteArray((byte[]) value);
-            } else if (dataType == MAP) {
-              comparable = new ByteArray(MapUtils.serializeMap((Map) value));
-            } else {
-              comparable = (Comparable) value;
-            }
+            Comparable comparable = toComparableValue(value, dataType, column);
             if (indexContainer._minValue == null) {
               indexContainer._minValue = comparable;
               indexContainer._maxValue = comparable;
@@ -1015,6 +1022,21 @@ public class MutableSegmentImpl implements MutableSegment {
       _multiColumnTextIndex.add(_multiColumnValues);
       Collections.fill(_multiColumnValues, null);
     }
+  }
+
+  private Comparable toComparableValue(Object value, DataType dataType) {
+    return toComparableValue(value, dataType, null);
+  }
+
+  private Comparable toComparableValue(Object value, DataType dataType, @Nullable String columnName) {
+    if (dataType == MAP) {
+      return new ByteArray(MapUtils.serializeMap((Map) value));
+    }
+    if (dataType.getStoredType() == BYTES) {
+      return new ByteArray((byte[]) value);
+    }
+    Preconditions.checkState(value instanceof Comparable, "Column: %s must be comparable", columnName);
+    return (Comparable) value;
   }
 
   private void updateIndexCapacityThresholdBreached(MutableIndex mutableIndex, IndexType indexType, String column) {
@@ -1452,7 +1474,8 @@ public class MutableSegmentImpl implements MutableSegment {
       docIds[i] = i;
     }
 
-    DataType storedType = indexContainer._fieldSpec.getDataType().getStoredType();
+    DataType dataType = indexContainer._fieldSpec.getDataType();
+    DataType storedType = dataType.getStoredType();
     switch (storedType) {
       case INT:
         IntArrays.quickSort(docIds, (d1, d2) -> Integer.compare(forwardIndex.getInt(d1), forwardIndex.getInt(d2)));
@@ -1474,8 +1497,13 @@ public class MutableSegmentImpl implements MutableSegment {
         IntArrays.quickSort(docIds, (d1, d2) -> forwardIndex.getString(d1).compareTo(forwardIndex.getString(d2)));
         break;
       case BYTES:
-        IntArrays.quickSort(docIds,
-            (d1, d2) -> ByteArray.compare(forwardIndex.getBytes(d1), forwardIndex.getBytes(d2)));
+        if (dataType == DataType.UUID) {
+          IntArrays.quickSort(docIds,
+              (d1, d2) -> UuidUtils.compare(forwardIndex.getBytes(d1), forwardIndex.getBytes(d2)));
+        } else {
+          IntArrays.quickSort(docIds,
+              (d1, d2) -> ByteArray.compare(forwardIndex.getBytes(d1), forwardIndex.getBytes(d2)));
+        }
         break;
       default:
         throw new UnsupportedOperationException(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
@@ -117,7 +117,9 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
 
     int numDocs = _dataSourceMetadata.getNumDocs();
 
-    // Verify that values are non-decreasing when iterated in the given order
+    // Verify that values are non-decreasing when iterated in the given order. The BYTES path uses
+    // ByteArray.compare (unsigned byte-wise lexicographic), which is identical to UuidUtils.compare's unsigned
+    // 64-bit-word ordering on canonical 16-byte big-endian UUIDs, so a single comparator handles both.
     DataType storedType = getStoredType();
     if (_sortedDocIds != null) {
       switch (storedType) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
@@ -66,7 +66,14 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   @Override
   public int[] index(Object[] values) {
-    throw new UnsupportedOperationException();
+    int numValues = values.length;
+    int[] dictIds = new int[numValues];
+    for (int i = 0; i < numValues; i++) {
+      byte[] bytesValue = (byte[]) values[i];
+      updateStats(bytesValue);
+      dictIds[i] = indexValue(new ByteArray(bytesValue), bytesValue);
+    }
+    return dictIds;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -46,7 +46,14 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int[] index(Object[] values) {
-    throw new UnsupportedOperationException();
+    int numValues = values.length;
+    int[] dictIds = new int[numValues];
+    for (int i = 0; i < numValues; i++) {
+      byte[] bytesValue = (byte[]) values[i];
+      updateStats(bytesValue);
+      dictIds[i] = indexValue(new ByteArray(bytesValue));
+    }
+    return dictIds;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -121,6 +121,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   private final String _context;
   private final boolean _isDictionaryEncoded;
   private final FieldSpec.DataType _storedType;
+  private final FieldSpec.DataType _dataType;
 
   private FixedByteSingleValueMultiColWriter _curHeaderWriter;
   private FixedByteSingleValueMultiColWriter _currentDataWriter;
@@ -132,6 +133,13 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   public FixedByteMVMutableForwardIndex(int maxNumberOfMultiValuesPerRow, int avgMultiValueCount, int rowCountPerChunk,
       int columnSizeInBytes, PinotDataBufferMemoryManager memoryManager, String context, boolean isDictionaryEncoded,
       FieldSpec.DataType storedType) {
+    this(maxNumberOfMultiValuesPerRow, avgMultiValueCount, rowCountPerChunk, columnSizeInBytes, memoryManager, context,
+        isDictionaryEncoded, storedType, storedType);
+  }
+
+  public FixedByteMVMutableForwardIndex(int maxNumberOfMultiValuesPerRow, int avgMultiValueCount, int rowCountPerChunk,
+      int columnSizeInBytes, PinotDataBufferMemoryManager memoryManager, String context, boolean isDictionaryEncoded,
+      FieldSpec.DataType storedType, FieldSpec.DataType dataType) {
     _memoryManager = memoryManager;
     _context = context;
     int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rowCountPerChunk * avgMultiValueCount);
@@ -148,6 +156,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     //init(_rowCountPerChunk, _columnSizeInBytes, _maxNumberOfMultiValuesPerRow, initialCapacity, _incrementalCapacity);
     _isDictionaryEncoded = isDictionaryEncoded;
     _storedType = storedType;
+    _dataType = dataType;
   }
 
   private void addHeaderBuffer() {
@@ -381,6 +390,37 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public int getBytesMV(int docId, byte[][] valueBuffer) {
+    checkBytesMvSupported();
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
+    FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    for (int i = 0; i < length; i++) {
+      valueBuffer[i] = dataReader.getBytes(startIndex + i, 0);
+    }
+    return length;
+  }
+
+  @Override
+  public byte[][] getBytesMV(int docId) {
+    checkBytesMvSupported();
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
+    FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    byte[][] valueBuffer = new byte[length][];
+    for (int i = 0; i < length; i++) {
+      valueBuffer[i] = dataReader.getBytes(startIndex + i, 0);
+    }
+    return valueBuffer;
+  }
+
+  @Override
   public int getNumValuesMV(int docId) {
     FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
     int rowInCurrentHeader = getRowInCurrentHeader(docId);
@@ -421,6 +461,26 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int newStartIndex = updateHeader(docId, values.length);
     for (int i = 0; i < values.length; i++) {
       _currentDataWriter.setDouble(newStartIndex + i, 0, values[i]);
+    }
+  }
+
+  @Override
+  public void setBytesMV(int docId, byte[][] values) {
+    checkBytesMvSupported();
+    int newStartIndex = updateHeader(docId, values.length);
+    for (int i = 0; i < values.length; i++) {
+      byte[] value = values[i];
+      if (value.length != _columnSizeInBytes) {
+        throw new IllegalArgumentException(
+            "Expected fixed-width bytes value of length: " + _columnSizeInBytes + ", got: " + value.length);
+      }
+      _currentDataWriter.setBytes(newStartIndex + i, 0, value);
+    }
+  }
+
+  private void checkBytesMvSupported() {
+    if (_dataType != DataType.UUID) {
+      throw new UnsupportedOperationException("Unsupported data type: " + _dataType + " for raw bytes MV index");
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
@@ -19,8 +19,12 @@
 package org.apache.pinot.segment.local.recordtransformer;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ThrottledLogger;
 import org.apache.pinot.segment.local.utils.DataTypeTransformerUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -52,21 +56,52 @@ public class DataTypeTransformer implements RecordTransformer {
   private final Map<String, PinotDataType> _dataTypes;
   private final boolean _continueOnError;
   private final ThrottledLogger _throttledLogger;
+  // UUID primary key columns for upsert/dedup tables; non-null and non-empty when applicable.
+  // Non-canonical (uppercase) UUID strings in these columns will be rejected at ingest time because
+  // Kafka partition routing is decided by the producer before Pinot normalises the value. Accepting
+  // uppercase UUIDs as primary keys silently causes dedup failures in multi-partition realtime
+  // upsert tables when the same logical UUID is routed to different partitions.
+  @Nullable
+  private final Set<String> _upsertUuidPrimaryKeyColumns;
 
   /// Creates a [DataTypeTransformer] that converts the (non-virtual) schema columns to the data types defined in the
   /// [Schema].
   public DataTypeTransformer(TableConfig tableConfig, Schema schema) {
-    this(tableConfig, extractSchemaDataTypes(schema));
+    this(tableConfig, extractSchemaDataTypes(schema), schema);
   }
 
   /// Creates a [DataTypeTransformer] that converts the given columns to the provided [PinotDataType]s. This is useful
   /// for fixing the data types of source fields before other transformers (such as [ExpressionTransformer]) consume
   /// them.
   public DataTypeTransformer(TableConfig tableConfig, Map<String, PinotDataType> dataTypes) {
+    this(tableConfig, dataTypes, null);
+  }
+
+  private DataTypeTransformer(TableConfig tableConfig, Map<String, PinotDataType> dataTypes, @Nullable Schema schema) {
     _dataTypes = dataTypes;
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     _continueOnError = ingestionConfig != null && ingestionConfig.isContinueOnError();
     _throttledLogger = new ThrottledLogger(LOGGER, ingestionConfig);
+
+    // Enforce canonical-form UUID PKs only when upsert/dedup is actually enabled — a present-but-disabled config
+    // (e.g., UpsertConfig with Mode.NONE) must not reject otherwise-valid rows.
+    if (schema != null && (tableConfig.isUpsertEnabled() || tableConfig.isDedupEnabled())) {
+      List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();
+      if (primaryKeyColumns != null && !primaryKeyColumns.isEmpty()) {
+        Set<String> uuidPkCols = new HashSet<>();
+        for (String col : primaryKeyColumns) {
+          FieldSpec spec = schema.getFieldSpecFor(col);
+          if (spec != null && spec.getDataType() == FieldSpec.DataType.UUID) {
+            uuidPkCols.add(col);
+          }
+        }
+        _upsertUuidPrimaryKeyColumns = uuidPkCols.isEmpty() ? null : Set.copyOf(uuidPkCols);
+      } else {
+        _upsertUuidPrimaryKeyColumns = null;
+      }
+    } else {
+      _upsertUuidPrimaryKeyColumns = null;
+    }
   }
 
   private static Map<String, PinotDataType> extractSchemaDataTypes(Schema schema) {
@@ -95,6 +130,10 @@ public class DataTypeTransformer implements RecordTransformer {
       String column = entry.getKey();
       try {
         Object value = record.getValue(column);
+        if (_upsertUuidPrimaryKeyColumns != null && _upsertUuidPrimaryKeyColumns.contains(column)
+            && value instanceof CharSequence) {
+          validateCanonicalUuidPrimaryKey(column, value.toString());
+        }
         value = DataTypeTransformerUtils.transformValue(column, value, entry.getValue());
         record.putValue(column, value);
       } catch (Exception e) {
@@ -105,6 +144,38 @@ public class DataTypeTransformer implements RecordTransformer {
         record.putValue(column, null);
         record.markIncomplete();
       }
+    }
+  }
+
+  /**
+   * Validates that a UUID primary key string value is in canonical lowercase RFC 4122 form.
+   *
+   * <p>UUID primary keys in upsert/dedup realtime tables must be canonical because Kafka partition routing
+   * is determined by the raw string value that the producer sends. If the producer sends the same logical
+   * UUID with different casing (e.g. uppercase vs lowercase), Kafka will hash the strings differently
+   * and the messages may land on different partitions. Pinot then normalises them to the same bytes
+   * inside each consuming segment, so within-segment dedup works, but cross-partition dedup never
+   * fires - producing duplicate or stale rows silently.
+   *
+   * <p>By rejecting non-canonical UUIDs here (before bytes conversion loses the original string),
+   * we ensure that any producer-side casing inconsistency surfaces as an ingestion error rather
+   * than a silent correctness failure. Producers must canonicalise UUID primary keys to lowercase
+   * before publishing to Kafka.
+   */
+  private static void validateCanonicalUuidPrimaryKey(String column, String uuidStr) {
+    String canonical;
+    try {
+      canonical = UUID.fromString(uuidStr).toString();
+    } catch (IllegalArgumentException e) {
+      // Malformed UUID; let DataTypeTransformerUtils.transformValue produce the standard error.
+      return;
+    }
+    if (!canonical.equals(uuidStr)) {
+      throw new IllegalArgumentException(
+          "Non-canonical UUID primary key value '" + uuidStr + "' in upsert/dedup column '" + column + "'. "
+              + "Expected canonical lowercase RFC 4122 form: '" + canonical + "'. "
+              + "UUID primary keys must be in canonical lowercase form to ensure consistent Kafka partition "
+              + "routing. Non-canonical values cause silent dedup failures in multi-partition realtime tables.");
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPreIndexStatsCollector.java
@@ -74,7 +74,12 @@ public class BytesColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
       addressSorted(value);
       if (_values.add(value)) {
         if (isPartitionEnabled()) {
-          updatePartition(value.toString());
+          // Use DataType.toString so UUID columns get their canonical RFC 4122 form (with dashes) rather
+          // than the bare hex from ByteArray.toString(). The runtime ingest path (MutableSegmentImpl) and
+          // every partition function (Murmur, Uuid) expect this canonical form; passing bare hex here
+          // produces a different partition value than runtime — silently breaking partition pruning — and
+          // throws for the Uuid partition function (UuidUtils.toBytes rejects no-dash strings).
+          updatePartition(_fieldSpec.getDataType().toString(entry));
         }
         int length = value.length();
         _minLength = Math.min(_minLength, length);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/NoDictColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/NoDictColumnStatisticsCollector.java
@@ -155,7 +155,11 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
         }
       }
       if (isPartitionEnabled()) {
-        updatePartition(comparable.toString());
+        // See BytesColumnPreIndexStatsCollector: UUID columns must use DataType.toString to produce the
+        // canonical dashed form that matches the runtime MutableSegmentImpl partition path and
+        // UuidPartitionFunction expectation. comparable.toString() for UUID would yield the bare hex
+        // (ByteArray.toString) which breaks both Murmur (different partition value) and Uuid (rejected).
+        updatePartition(_fieldSpec.getDataType().toString(entry));
       }
       _totalNumberOfEntries++;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -70,6 +70,7 @@ public class DefaultNullValueVirtualColumnProvider implements VirtualColumnProvi
       case STRING:
         return new ConstantValueStringDictionary((String) fieldSpec.getDefaultNullValue());
       case BYTES:
+      case UUID:
         return new ConstantValueBytesDictionary((byte[]) fieldSpec.getDefaultNullValue());
       default:
         throw new IllegalStateException();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
@@ -364,7 +364,8 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
     }
     String column = context.getFieldSpec().getName();
     String segmentName = context.getSegmentName();
-    FieldSpec.DataType storedType = context.getFieldSpec().getDataType().getStoredType();
+    FieldSpec.DataType dataType = context.getFieldSpec().getDataType();
+    FieldSpec.DataType storedType = dataType.getStoredType();
     int fixedLengthBytes = context.getFixedLengthBytes();
     boolean isSingleValue = context.getFieldSpec().isSingleValueField();
     if (!context.hasDictionary()) {
@@ -402,13 +403,15 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
         }
       } else {
         // TODO: Add support for variable width (bytes, string, big decimal) MV RAW column types
-        assert storedType.isFixedWidth();
+        Preconditions.checkState(dataType.isFixedWidth(), "Unsupported stored type: %s for no-dictionary MV column: %s",
+            storedType, column);
         String allocationContext =
             IndexUtil.buildAllocationContext(context.getSegmentName(), context.getFieldSpec().getName(),
                 V1Constants.Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
         // TODO: Start with a smaller capacity on FixedByteMVForwardIndexReaderWriter and let it expand
         return new FixedByteMVMutableForwardIndex(MAX_MULTI_VALUES_PER_ROW, context.getAvgNumMultiValues(),
-            context.getCapacity(), storedType.size(), context.getMemoryManager(), allocationContext, false, storedType);
+            context.getCapacity(), dataType.size(), context.getMemoryManager(), allocationContext, false, storedType,
+            dataType);
       }
     } else {
       if (isSingleValue) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -360,15 +360,17 @@ public class ColumnMinMaxValueGenerator {
           break;
         }
         case BYTES: {
+          // ByteArray.compare is unsigned byte-wise lexicographic; for canonical 16-byte big-endian UUIDs this is
+          // identical to UuidUtils.compare's unsigned 64-bit-word ordering, so a single comparator is sufficient.
           byte[] min = null;
           byte[] max = null;
           if (isSingleValue) {
             for (int docId = 0; docId < numDocs; docId++) {
               byte[] value = rawIndexReader.getBytes(docId, readerContext);
-              if (min == null || ByteArray.compare(value, min) > 0) {
+              if (min == null || ByteArray.compare(value, min) < 0) {
                 min = value;
               }
-              if (max == null || ByteArray.compare(value, max) < 0) {
+              if (max == null || ByteArray.compare(value, max) > 0) {
                 max = value;
               }
             }
@@ -376,10 +378,10 @@ public class ColumnMinMaxValueGenerator {
             for (int docId = 0; docId < numDocs; docId++) {
               byte[][] values = rawIndexReader.getBytesMV(docId, readerContext);
               for (byte[] value : values) {
-                if (min == null || ByteArray.compare(value, min) > 0) {
+                if (min == null || ByteArray.compare(value, min) < 0) {
                   min = value;
                 }
-                if (max == null || ByteArray.compare(value, max) < 0) {
+                if (max == null || ByteArray.compare(value, max) > 0) {
                   max = value;
                 }
               }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BytesDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BytesDictionary.java
@@ -30,7 +30,6 @@ import org.apache.pinot.spi.utils.BytesUtils;
  * Extension of {@link BaseImmutableDictionary} that implements immutable dictionary for byte[] type.
  */
 public class BytesDictionary extends BaseImmutableDictionary {
-
   public BytesDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue) {
     super(dataBuffer, length, numBytesPerValue);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -641,6 +641,8 @@ public class PinotSegmentColumnReader implements Closeable {
         return _forwardIndexReader.getString(docId1, _forwardIndexReaderContext)
             .compareTo(_forwardIndexReader.getString(docId2, _forwardIndexReaderContext));
       case BYTES:
+        // ByteArray.compare is unsigned byte-wise lexicographic; for canonical 16-byte big-endian UUIDs this is
+        // identical to UuidUtils.compare's unsigned 64-bit-word ordering, so a single comparator handles both.
         return ByteArray.compare(_forwardIndexReader.getBytes(docId1, _forwardIndexReaderContext),
             _forwardIndexReader.getBytes(docId2, _forwardIndexReaderContext));
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 public class HashUtils {
@@ -47,6 +48,15 @@ public class HashUtils {
   /**
    * Returns a byte array that is a concatenation of the binary representation of each of the passed UUID values.
    * If any of the values is not a valid UUID, then we return the result of {@link PrimaryKey#asBytes()}.
+   *
+   * <p>String inputs are parsed via {@link UUID#fromString(String)} (lenient — accepts non-canonical short
+   * forms like {@code "1-2-3-4-5"}) for backward compatibility with tables that have been hashed under the
+   * pre-UUID-type {@code HashFunction.UUID} contract. Binary inputs ({@code byte[]} or {@link UUID}) go
+   * through {@link UuidUtils#toBytes(Object)} since they carry no parse ambiguity. Un-parseable strings
+   * (and any other invalid value) still fall through to {@link PrimaryKey#asBytes()} via the outer
+   * {@code catch (RuntimeException)} below — matching master's behavior. Newly-declared
+   * {@code DataType.UUID} primary-key columns are independently constrained to canonical form at ingest
+   * time by {@code DataTypeTransformer.validateCanonicalUuidPrimaryKey}.
    */
   public static byte[] hashUUID(PrimaryKey primaryKey) {
     Object[] values = primaryKey.getValues();
@@ -56,14 +66,17 @@ public class HashUtils {
       if (value == null) {
         throw new IllegalArgumentException("Found null value in primary key");
       }
-      UUID uuid;
       try {
-        uuid = UUID.fromString(value.toString());
-      } catch (Throwable t) {
+        if (value instanceof CharSequence) {
+          UUID uuid = UUID.fromString(value.toString());
+          byteBuffer.putLong(uuid.getMostSignificantBits());
+          byteBuffer.putLong(uuid.getLeastSignificantBits());
+        } else {
+          byteBuffer.put(UuidUtils.toBytes(value));
+        }
+      } catch (RuntimeException e) {
         return primaryKey.asBytes();
       }
-      byteBuffer.putLong(uuid.getMostSignificantBits());
-      byteBuffer.putLong(uuid.getLeastSignificantBits());
     }
     return result;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUuidPrimaryKeyTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUuidPrimaryKeyTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.indexsegment.mutable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Regression tests for UUID primary-key normalization during realtime upsert ingestion.
+ */
+public class MutableSegmentImplUuidPrimaryKeyTest {
+  private static final String UUID_PK_COLUMN = "uuidPk";
+  private static final String VALUE_COLUMN = "payload";
+  private static final String TIME_COLUMN = "ts";
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder()
+      .addSingleValueDimension(UUID_PK_COLUMN, FieldSpec.DataType.UUID)
+      .addSingleValueDimension(VALUE_COLUMN, FieldSpec.DataType.STRING)
+      .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+      .setPrimaryKeyColumns(List.of(UUID_PK_COLUMN))
+      .build();
+
+  private MutableSegmentImpl _segment;
+
+  @AfterMethod
+  public void tearDown() {
+    if (_segment != null) {
+      _segment.destroy();
+      _segment = null;
+    }
+  }
+
+  @Test
+  public void testUpsertPrimaryKeyNormalizesMixedCaseUuidStrings()
+      throws ReflectiveOperationException {
+    _segment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, false, TIME_COLUMN, null, null);
+
+    PrimaryKey firstPrimaryKey = getPrimaryKey(createRow(UUID_VALUE.toUpperCase(), 1L));
+    PrimaryKey secondPrimaryKey = getPrimaryKey(createRow(UUID_VALUE, 2L));
+    assertEquals(firstPrimaryKey, secondPrimaryKey);
+    assertTrue(firstPrimaryKey.getValues()[0] instanceof ByteArray);
+    assertEquals(firstPrimaryKey.getValues()[0], new ByteArray(UuidUtils.toBytes(UUID_VALUE)));
+  }
+
+  private GenericRow createRow(String uuidValue, long timestamp) {
+    GenericRow row = new GenericRow();
+    row.putValue(UUID_PK_COLUMN, uuidValue);
+    row.putValue(VALUE_COLUMN, "payload-" + timestamp);
+    row.putValue(TIME_COLUMN, timestamp);
+    return row;
+  }
+
+  private PrimaryKey getPrimaryKey(GenericRow row)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method getPrimaryKeyMethod = MutableSegmentImpl.class.getDeclaredMethod("getPrimaryKey", GenericRow.class);
+    getPrimaryKeyMethod.setAccessible(true);
+    return (PrimaryKey) getPrimaryKeyMethod.invoke(_segment, row);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -20,11 +20,14 @@ package org.apache.pinot.segment.local.realtime.impl.dictionary;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.pinot.segment.local.PinotBuffersAfterClassCheckRule;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteMVMutableForwardIndex;
+import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -86,6 +89,31 @@ public class MultiValueDictionaryTest implements PinotBuffersAfterClassCheckRule
     } catch (Throwable t) {
       fail("Failed with random seed: " + seed, t);
     }
+  }
+
+  @Test
+  public void testMultiValueBytesIndexingWithDictionary()
+      throws Exception {
+    try (MutableDictionary dictionary = new BytesOnHeapMutableDictionary()) {
+      assertMultiValueBytesIndexingWithDictionary(dictionary);
+    }
+    try (MutableDictionary dictionary =
+        new BytesOffHeapMutableDictionary(4, 10, _memoryManager, "bytesDictionary", 4)) {
+      assertMultiValueBytesIndexingWithDictionary(dictionary);
+    }
+  }
+
+  private static void assertMultiValueBytesIndexingWithDictionary(MutableDictionary dictionary) {
+    byte[] first = new byte[]{1, 2};
+    byte[] second = new byte[]{3, 4, 5};
+    byte[] third = new byte[]{6};
+
+    assertEquals(dictionary.index(new Object[]{first, second, first}), new int[]{0, 1, 0});
+    assertEquals(dictionary.index(new Object[]{third, second}), new int[]{2, 1});
+    assertEquals(dictionary.length(), 3);
+    assertEquals(dictionary.getBytesValue(0), first);
+    assertEquals(dictionary.getBytesValue(1), second);
+    assertEquals(dictionary.getBytesValue(2), third);
   }
 
   @Test
@@ -284,6 +312,31 @@ public class MultiValueDictionaryTest implements PinotBuffersAfterClassCheckRule
       }
     } catch (Throwable t) {
       fail("Failed with random seed: " + seed, t);
+    }
+  }
+
+  @Test
+  public void testMultiValueIndexingWithRawUuidBytes()
+      throws Exception {
+    try (DirectMemoryManager memManager = new DirectMemoryManager("test");
+        FixedByteMVMutableForwardIndex indexer = new FixedByteMVMutableForwardIndex(MAX_N_VALUES, MAX_N_VALUES / 2,
+            NROWS / 3, UuidUtils.UUID_NUM_BYTES, memManager, "indexer", false, FieldSpec.DataType.BYTES,
+            FieldSpec.DataType.UUID)) {
+      byte[][] values = new byte[][]{
+          UuidUtils.toBytes(new UUID(1L, 2L)),
+          UuidUtils.toBytes(new UUID(3L, 4L))
+      };
+      indexer.setBytesMV(0, values);
+
+      byte[][] buffer = new byte[values.length][];
+      assertEquals(indexer.getBytesMV(0, buffer), values.length);
+      for (int i = 0; i < values.length; i++) {
+        assertEquals(buffer[i], values[i]);
+      }
+      byte[][] actualValues = indexer.getBytesMV(0);
+      for (int i = 0; i < values.length; i++) {
+        assertEquals(actualValues[i], values[i]);
+      }
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
@@ -23,6 +23,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.segment.local.utils.DataTypeTransformerUtils;
+import org.apache.pinot.spi.config.table.DedupConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -200,5 +208,83 @@ public class DataTypeTransformerTest {
       // Expected
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformerUtils.standardize(COLUMN, values, false), expectedValues);
+  }
+
+  /**
+   * Verifies that non-canonical (uppercase) UUID strings in upsert/dedup primary key columns are rejected,
+   * while canonical lowercase UUIDs are accepted, and non-primary-key UUID columns are unaffected.
+   */
+  @Test
+  public void testUuidUpsertPrimaryKeyCanonicalValidation() {
+    String uuidCol = "uuidPk";
+    String nonPkUuidCol = "uuidOther";
+    String canonicalUuid = "550e8400-e29b-41d4-a716-446655440000";
+    String uppercaseUuid = "550E8400-E29B-41D4-A716-446655440000";
+
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(uuidCol, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(nonPkUuidCol, FieldSpec.DataType.UUID)
+        .setPrimaryKeyColumns(List.of(uuidCol))
+        .build();
+    TableConfig upsertTableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("testUpsertUuid")
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
+        .build();
+
+    DataTypeTransformer upsertTransformer = new DataTypeTransformer(upsertTableConfig, schema);
+
+    // Canonical lowercase UUID primary key: accepted
+    GenericRow canonicalRow = new GenericRow();
+    canonicalRow.putValue(uuidCol, canonicalUuid);
+    canonicalRow.putValue(nonPkUuidCol, canonicalUuid);
+    upsertTransformer.transform(canonicalRow); // must not throw
+
+    // Non-canonical uppercase UUID primary key: rejected
+    GenericRow uppercaseRow = new GenericRow();
+    uppercaseRow.putValue(uuidCol, uppercaseUuid);
+    uppercaseRow.putValue(nonPkUuidCol, canonicalUuid);
+    try {
+      upsertTransformer.transform(uppercaseRow);
+      fail("Expected RuntimeException for non-canonical UUID primary key in upsert table");
+    } catch (RuntimeException e) {
+      // Expected: DataTypeTransformer wraps the IllegalArgumentException in a RuntimeException
+    }
+
+    // Non-canonical uppercase UUID in a NON-primary-key column: accepted (no restriction)
+    GenericRow nonPkUppercaseRow = new GenericRow();
+    nonPkUppercaseRow.putValue(uuidCol, canonicalUuid);
+    nonPkUppercaseRow.putValue(nonPkUuidCol, uppercaseUuid);
+    upsertTransformer.transform(nonPkUppercaseRow); // must not throw
+
+    // For a non-upsert table, non-canonical UUID in primary-key column is also accepted
+    TableConfig offlineTableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testOfflineUuid").build();
+    DataTypeTransformer offlineTransformer = new DataTypeTransformer(offlineTableConfig, schema);
+    GenericRow offlineUppercaseRow = new GenericRow();
+    offlineUppercaseRow.putValue(uuidCol, uppercaseUuid);
+    offlineUppercaseRow.putValue(nonPkUuidCol, uppercaseUuid);
+    offlineTransformer.transform(offlineUppercaseRow); // must not throw
+
+    // A present-but-disabled upsert config (Mode.NONE) must not enforce the canonical-PK restriction
+    TableConfig disabledUpsertTableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("testDisabledUpsertUuid")
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.NONE))
+        .build();
+    DataTypeTransformer disabledUpsertTransformer = new DataTypeTransformer(disabledUpsertTableConfig, schema);
+    GenericRow disabledUpsertUppercaseRow = new GenericRow();
+    disabledUpsertUppercaseRow.putValue(uuidCol, uppercaseUuid);
+    disabledUpsertUppercaseRow.putValue(nonPkUuidCol, canonicalUuid);
+    disabledUpsertTransformer.transform(disabledUpsertUppercaseRow); // must not throw
+
+    // A present-but-disabled dedup config must not enforce the canonical-PK restriction either
+    TableConfig disabledDedupTableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("testDisabledDedupUuid")
+        .setDedupConfig(new DedupConfig(false, null))
+        .build();
+    DataTypeTransformer disabledDedupTransformer = new DataTypeTransformer(disabledDedupTableConfig, schema);
+    GenericRow disabledDedupUppercaseRow = new GenericRow();
+    disabledDedupUppercaseRow.putValue(uuidCol, uppercaseUuid);
+    disabledDedupUppercaseRow.putValue(nonPkUuidCol, canonicalUuid);
+    disabledDedupTransformer.transform(disabledDedupUppercaseRow); // must not throw
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -45,6 +46,7 @@ public class DefaultNullValueVirtualColumnProviderTest {
   private static final FieldSpec SV_STRING_WITH_DEFAULT =
       new DimensionFieldSpec("svStringColumn", DataType.STRING, true, "default");
   private static final FieldSpec SV_BYTES = new DimensionFieldSpec("svBytesColumn", DataType.BYTES, true);
+  private static final FieldSpec SV_UUID = new DimensionFieldSpec("svUuidColumn", DataType.UUID, true);
   private static final FieldSpec MV_INT = new DimensionFieldSpec("mvIntColumn", DataType.INT, false);
   private static final FieldSpec MV_LONG = new DimensionFieldSpec("mvLongColumn", DataType.LONG, false);
   private static final FieldSpec MV_FLOAT = new DimensionFieldSpec("mvFloatColumn", DataType.FLOAT, false);
@@ -87,6 +89,11 @@ public class DefaultNullValueVirtualColumnProviderTest {
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_BYTES).setTotalDocs(1).setCardinality(1).setSorted(true)
             .setHasDictionary(true).setMinValue(new ByteArray((byte[]) SV_BYTES.getDefaultNullValue()))
             .setMaxValue(new ByteArray((byte[]) SV_BYTES.getDefaultNullValue())).build());
+
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_UUID, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(SV_UUID).setTotalDocs(1).setCardinality(1).setSorted(true)
+            .setHasDictionary(true).setMinValue(new ByteArray((byte[]) SV_UUID.getDefaultNullValue()))
+            .setMaxValue(new ByteArray((byte[]) SV_UUID.getDefaultNullValue())).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setCardinality(1).setSorted(false)
@@ -145,6 +152,14 @@ public class DefaultNullValueVirtualColumnProviderTest {
     dictionary = new DefaultNullValueVirtualColumnProvider().buildDictionary(virtualColumnContext);
     assertEquals(dictionary.getClass(), ConstantValueBytesDictionary.class);
     assertEquals(dictionary.getBytesValue(0), new byte[0]);
+
+    virtualColumnContext = new VirtualColumnContext(SV_UUID, 1);
+    dictionary = new DefaultNullValueVirtualColumnProvider().buildDictionary(virtualColumnContext);
+    assertEquals(dictionary.getClass(), ConstantValueBytesDictionary.class);
+    byte[] uuidDefaultNullValue = (byte[]) SV_UUID.getDefaultNullValue();
+    assertEquals(dictionary.getBytesValue(0), uuidDefaultNullValue);
+    assertEquals(dictionary.getStringValue(0), BytesUtils.toHexString(uuidDefaultNullValue));
+    assertEquals(dictionary.indexOf(BytesUtils.toHexString(uuidDefaultNullValue)), 0);
 
     virtualColumnContext = new VirtualColumnContext(MV_INT, 1);
     dictionary = new DefaultNullValueVirtualColumnProvider().buildDictionary(virtualColumnContext);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BloomFilterCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BloomFilterCreatorTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -72,6 +73,33 @@ public class BloomFilterCreatorTest implements PinotBuffersAfterMethodCheckRule 
         Assert.assertFalse(onHeapBloomFilter.mightContain(Integer.toString(i)));
         Assert.assertFalse(offHeapBloomFilter.mightContain(Integer.toString(i)));
       }
+    }
+  }
+
+  @Test
+  public void testUuidBloomFilterCreatorWithBytesValues()
+      throws Exception {
+    int cardinality = 100;
+    String columnName = "uuidColumn";
+    String uuid0 = "550e8400-e29b-41d4-a716-446655440000";
+    String uuid1 = "550e8400-e29b-41d4-a716-446655440001";
+    try (BloomFilterCreator bloomFilterCreator = new OnHeapGuavaBloomFilterCreator(TEMP_DIR, columnName, cardinality,
+        new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 0, false), FieldSpec.DataType.UUID)) {
+      bloomFilterCreator.add(UuidUtils.toBytes(uuid0), -1);
+      bloomFilterCreator.add(UuidUtils.toBytes(uuid1), -1);
+      bloomFilterCreator.seal();
+    }
+
+    File bloomFilterFile = new File(TEMP_DIR, columnName + V1Constants.Indexes.BLOOM_FILTER_FILE_EXTENSION);
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(bloomFilterFile);
+        BloomFilterReader onHeapBloomFilter = BloomFilterReaderFactory.getBloomFilterReader(dataBuffer, true);
+        BloomFilterReader offHeapBloomFilter = BloomFilterReaderFactory.getBloomFilterReader(dataBuffer, false)) {
+      Assert.assertTrue(onHeapBloomFilter.mightContain(uuid0));
+      Assert.assertTrue(onHeapBloomFilter.mightContain(uuid1));
+      Assert.assertFalse(onHeapBloomFilter.mightContain("550e8400-e29b-41d4-a716-4466554400ff"));
+      Assert.assertTrue(offHeapBloomFilter.mightContain(uuid0));
+      Assert.assertTrue(offHeapBloomFilter.mightContain(uuid1));
+      Assert.assertFalse(offHeapBloomFilter.mightContain("550e8400-e29b-41d4-a716-4466554400ff"));
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGeneratorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGeneratorTest.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.loader.columnminmaxvalue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Regression tests for {@link ColumnMinMaxValueGenerator} on raw (no-dictionary) BYTES and UUID columns.
+ *
+ * <p>The raw-BYTES loop once had its comparison directions inverted ({@code > 0} accepted as new min,
+ * {@code < 0} as new max), silently persisting swapped min/max metadata that value-based segment pruning then
+ * consumed. These tests build a real segment, strip the min/max metadata the segment-build stats collector wrote,
+ * re-generate via the loader path, and assert the persisted direction.
+ */
+public class ColumnMinMaxValueGeneratorTest {
+  private static final File TEMP_DIR =
+      new File(FileUtils.getTempDirectory(), ColumnMinMaxValueGeneratorTest.class.getSimpleName());
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final String BYTES_COLUMN = "bytesCol";
+  private static final String BYTES_MV_COLUMN = "bytesMvCol";
+  private static final String UUID_COLUMN = "uuidCol";
+
+  // Ordered ascending by unsigned byte-wise comparison
+  private static final byte[] BYTES_SMALL = new byte[]{0x00, 0x01};
+  private static final byte[] BYTES_MID = new byte[]{0x10, (byte) 0xff};
+  private static final byte[] BYTES_LARGE = new byte[]{(byte) 0x80, 0x00};
+
+  private static final String UUID_SMALL = "00000000-0000-0000-0000-000000000001";
+  private static final String UUID_MID = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String UUID_LARGE = "ffffffff-ffff-ffff-ffff-fffffffffffe";
+
+  @Test
+  public void testRawBytesAndUuidMinMaxDirection()
+      throws Exception {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testSchema")
+        .addSingleValueDimension(BYTES_COLUMN, DataType.BYTES)
+        .addMultiValueDimension(BYTES_MV_COLUMN, DataType.BYTES)
+        .addSingleValueDimension(UUID_COLUMN, DataType.UUID)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setNoDictionaryColumns(List.of(BYTES_COLUMN, BYTES_MV_COLUMN, UUID_COLUMN))
+        .build();
+
+    File indexDir = buildSegment(tableConfig, schema);
+    removeMinMaxValuesFromMetadataFile(indexDir);
+
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
+    try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(indexDir, segmentMetadata, ReadMode.mmap);
+        SegmentDirectory.Writer writer = segmentDirectory.createWriter()) {
+      ColumnMinMaxValueGenerator generator =
+          new ColumnMinMaxValueGenerator(segmentMetadata, writer, ColumnMinMaxValueGeneratorMode.ALL);
+      generator.addColumnMinMaxValue();
+    }
+
+    SegmentMetadataImpl reloaded = new SegmentMetadataImpl(indexDir);
+
+    Comparable<?> bytesMin = reloaded.getColumnMetadataFor(BYTES_COLUMN).getMinValue();
+    Comparable<?> bytesMax = reloaded.getColumnMetadataFor(BYTES_COLUMN).getMaxValue();
+    assertNotNull(bytesMin);
+    assertNotNull(bytesMax);
+    assertEquals(bytesMin, new ByteArray(BYTES_SMALL), "Raw BYTES min must be the smallest unsigned value");
+    assertEquals(bytesMax, new ByteArray(BYTES_LARGE), "Raw BYTES max must be the largest unsigned value");
+    assertTrue(((ByteArray) bytesMin).compareTo((ByteArray) bytesMax) < 0, "min must order before max");
+
+    Comparable<?> uuidMin = reloaded.getColumnMetadataFor(UUID_COLUMN).getMinValue();
+    Comparable<?> uuidMax = reloaded.getColumnMetadataFor(UUID_COLUMN).getMaxValue();
+    assertNotNull(uuidMin);
+    assertNotNull(uuidMax);
+    assertEquals(uuidMin, new ByteArray(UuidUtils.toBytes(UUID_SMALL)),
+        "UUID min must be the smallest canonical UUID");
+    assertEquals(uuidMax, new ByteArray(UuidUtils.toBytes(UUID_LARGE)),
+        "UUID max must be the largest canonical UUID");
+
+    // The raw-BYTES MV loop is a distinct code path sharing the comparator with the SV loop
+    Comparable<?> bytesMvMin = reloaded.getColumnMetadataFor(BYTES_MV_COLUMN).getMinValue();
+    Comparable<?> bytesMvMax = reloaded.getColumnMetadataFor(BYTES_MV_COLUMN).getMaxValue();
+    assertNotNull(bytesMvMin);
+    assertNotNull(bytesMvMax);
+    assertEquals(bytesMvMin, new ByteArray(BYTES_SMALL), "Raw MV BYTES min must be the smallest unsigned value");
+    assertEquals(bytesMvMax, new ByteArray(BYTES_LARGE), "Raw MV BYTES max must be the largest unsigned value");
+  }
+
+  private static File buildSegment(TableConfig tableConfig, Schema schema)
+      throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(TEMP_DIR.getAbsolutePath());
+    config.setSegmentName(SEGMENT_NAME);
+
+    List<GenericRow> rows = new ArrayList<>();
+    // Deliberately insert in non-sorted order so the running min/max comparisons are both exercised
+    for (Object[] values : new Object[][]{
+        {BYTES_MID, UuidUtils.toBytes(UUID_MID)},
+        {BYTES_LARGE, UuidUtils.toBytes(UUID_LARGE)},
+        {BYTES_SMALL, UuidUtils.toBytes(UUID_SMALL)}
+    }) {
+      GenericRow row = new GenericRow();
+      row.putValue(BYTES_COLUMN, values[0]);
+      // Each MV row carries two values so the inner per-value loop is exercised as well
+      row.putValue(BYTES_MV_COLUMN, new Object[]{values[0], BYTES_MID});
+      row.putValue(UUID_COLUMN, values[1]);
+      rows.add(row);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+    return new File(TEMP_DIR, SEGMENT_NAME);
+  }
+
+  private static void removeMinMaxValuesFromMetadataFile(File indexDir)
+      throws Exception {
+    PropertiesConfiguration configuration = SegmentMetadataUtils.getPropertiesConfiguration(indexDir);
+    Iterator<String> keys = configuration.getKeys();
+    List<String> keysToClear = new ArrayList<>();
+    while (keys.hasNext()) {
+      String key = keys.next();
+      if (key.endsWith(V1Constants.MetadataKeys.Column.MIN_VALUE)
+          || key.endsWith(V1Constants.MetadataKeys.Column.MAX_VALUE)
+          || key.endsWith(V1Constants.MetadataKeys.Column.MIN_MAX_VALUE_INVALID)) {
+        keysToClear.add(key);
+      }
+    }
+    for (String key : keysToClear) {
+      configuration.clearProperty(key);
+    }
+    SegmentMetadataUtils.savePropertiesConfiguration(configuration, indexDir);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/LazyRowTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/LazyRowTest.java
@@ -22,9 +22,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -92,6 +95,15 @@ public class LazyRowTest {
     DataSource col2Datasource = mock(DataSource.class);
     when(segment.getDataSource("col1")).thenReturn(_col1Datasource);
     when(segment.getDataSource("col2")).thenReturn(col2Datasource);
+
+    DataSourceMetadata col1Metadata = mock(DataSourceMetadata.class);
+    DataSourceMetadata col2Metadata = mock(DataSourceMetadata.class);
+    FieldSpec col1FieldSpec = new DimensionFieldSpec("col1", FieldSpec.DataType.STRING, true);
+    FieldSpec col2FieldSpec = new DimensionFieldSpec("col2", FieldSpec.DataType.STRING, true);
+    when(col1Metadata.getFieldSpec()).thenReturn(col1FieldSpec);
+    when(col2Metadata.getFieldSpec()).thenReturn(col2FieldSpec);
+    when(_col1Datasource.getDataSourceMetadata()).thenReturn(col1Metadata);
+    when(col2Datasource.getDataSourceMetadata()).thenReturn(col2Metadata);
 
     NullValueVectorReader col1NullVectorReader = mock(NullValueVectorReader.class);
     when(col1NullVectorReader.isNull(1)).thenReturn(true);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest.java
@@ -44,12 +44,14 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
@@ -105,6 +107,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest
     when(forwardIndex.getInt(anyInt(), any())).thenAnswer(
         invocation -> primaryKeys.get(invocation.getArgument(0)).getValues()[0]);
     when(dataSource.getForwardIndex()).thenReturn(forwardIndex);
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(PRIMARY_KEY_COLUMNS.get(0), FieldSpec.DataType.INT, true));
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
     SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
     long creationTimeMs = System.currentTimeMillis();
     when(segmentMetadata.getIndexCreationTime()).thenReturn(creationTimeMs);
@@ -134,6 +140,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest
     when(forwardIndex.getInt(anyInt(), any())).thenAnswer(
         invocation -> primaryKeys.get(invocation.getArgument(0)).getValues()[0]);
     when(dataSource.getForwardIndex()).thenReturn(forwardIndex);
+    DataSourceMetadata uploadedDataSourceMetadata = mock(DataSourceMetadata.class);
+    when(uploadedDataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(PRIMARY_KEY_COLUMNS.get(0), FieldSpec.DataType.INT, true));
+    when(dataSource.getDataSourceMetadata()).thenReturn(uploadedDataSourceMetadata);
     SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
     when(segmentMetadata.getIndexCreationTime()).thenReturn(creationTimeMs);
     when(segmentMetadata.getZkCreationTime()).thenReturn(creationTimeMs);
@@ -186,6 +196,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest
       return docId;
     });
     when(dataSource.getForwardIndex()).thenReturn(forwardIndex);
+    DataSourceMetadata mutableDataSourceMetadata = mock(DataSourceMetadata.class);
+    when(mutableDataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(PRIMARY_KEY_COLUMNS.get(0), FieldSpec.DataType.INT, true));
+    when(dataSource.getDataSourceMetadata()).thenReturn(mutableDataSourceMetadata);
 
     when(segment.getDataSource(anyString())).thenReturn(dataSource);
     when(segment.getDataSource(PRIMARY_KEY_COLUMNS.get(0))).thenReturn(dataSource);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -50,6 +50,7 @@ import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
@@ -880,6 +881,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       return MOCK_FALLBACK_BASE_OFFSET + docId;
     });
     when(primaryKeyDataSource.getForwardIndex()).thenReturn(primaryKeyForwardIndex);
+    DataSourceMetadata primaryKeyDataSourceMetadata = mock(DataSourceMetadata.class);
+    when(primaryKeyDataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(PRIMARY_KEY_COLUMNS.get(0), DataType.INT, true));
+    when(primaryKeyDataSource.getDataSourceMetadata()).thenReturn(primaryKeyDataSourceMetadata);
 
     // Mock comparison column data source
     DataSource comparisonDataSource = mock(DataSource.class);
@@ -896,6 +901,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       return MOCK_FALLBACK_BASE_OFFSET + (docId * 100);
     });
     when(comparisonDataSource.getForwardIndex()).thenReturn(comparisonForwardIndex);
+    DataSourceMetadata comparisonDataSourceMetadata = mock(DataSourceMetadata.class);
+    when(comparisonDataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(COMPARISON_COLUMNS.get(0), DataType.INT, true));
+    when(comparisonDataSource.getDataSourceMetadata()).thenReturn(comparisonDataSourceMetadata);
 
     // Set up data source mapping - IMPORTANT: anyString() must be registered FIRST,
     // then specific matchers override it (Mockito uses last matching stub)
@@ -993,6 +1002,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     when(forwardIndex.getInt(anyInt(), any())).thenAnswer(
         invocation -> primaryKeys.get(invocation.getArgument(0)).getValues()[0]);
     when(dataSource.getForwardIndex()).thenReturn(forwardIndex);
+    DataSourceMetadata uploadedDataSourceMetadata = mock(DataSourceMetadata.class);
+    when(uploadedDataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(PRIMARY_KEY_COLUMNS.get(0), DataType.INT, true));
+    when(dataSource.getDataSourceMetadata()).thenReturn(uploadedDataSourceMetadata);
     SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
     when(segmentMetadata.getIndexCreationTime()).thenReturn(creationTimeMs);
     when(segmentMetadata.getZkCreationTime()).thenReturn(creationTimeMs);
@@ -1064,6 +1077,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       return docId;
     });
     when(dataSource.getForwardIndex()).thenReturn(forwardIndex);
+    DataSourceMetadata mutableDataSourceMetadata = mock(DataSourceMetadata.class);
+    when(mutableDataSourceMetadata.getFieldSpec()).thenReturn(
+        new DimensionFieldSpec(PRIMARY_KEY_COLUMNS.get(0), DataType.INT, true));
+    when(dataSource.getDataSourceMetadata()).thenReturn(mutableDataSourceMetadata);
 
     when(segment.getDataSource(anyString())).thenReturn(dataSource);
     when(segment.getDataSource(PRIMARY_KEY_COLUMNS.get(0))).thenReturn(dataSource);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
@@ -21,9 +21,11 @@ package org.apache.pinot.segment.local.utils;
 import java.util.UUID;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -47,6 +49,7 @@ public class HashUtilsTest {
     // Test happy cases: when all UUID values are valid
     testHashUUID(new UUID[]{UUID.randomUUID()});
     testHashUUID(new UUID[]{UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()});
+    testHashUUIDNormalizedPrimaryKeyValues();
 
     // Test failure scenario when there's a non-null invalid uuid value
     PrimaryKey invalidUUIDs = new PrimaryKey(new String[]{"some-random-string"});
@@ -62,6 +65,80 @@ public class HashUtilsTest {
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("Found null value"));
     }
+  }
+
+  @Test
+  public void testHashUUIDNormalizedPrimaryKeyValues() {
+    UUID firstUuid = UUID.randomUUID();
+    UUID secondUuid = UUID.randomUUID();
+
+    byte[] expectedHash = HashUtils.hashUUID(new PrimaryKey(new Object[]{firstUuid, secondUuid}));
+    assertEquals(HashUtils.hashUUID(new PrimaryKey(
+        new Object[]{new ByteArray(UuidUtils.toBytes(firstUuid)), new ByteArray(UuidUtils.toBytes(secondUuid))})),
+        expectedHash);
+    assertEquals(HashUtils.hashUUID(
+        new PrimaryKey(new Object[]{UuidUtils.toBytes(firstUuid), UuidUtils.toBytes(secondUuid)})), expectedHash);
+  }
+
+  /**
+   * Regression: {@link HashUtils#hashUUID} must accept non-canonical-but-Java-parseable UUID strings
+   * (e.g. {@code "1-2-3-4-5"}) so existing upsert tables using {@code HashFunction.UUID} keep producing
+   * the same hash before and after this PR. {@link UuidUtils#toBytes(String)} is strict and would reject
+   * such inputs — for the legacy hash path we route String inputs through {@code UUID.fromString} directly
+   * to preserve the lenient pre-PR behavior.
+   */
+  @Test
+  public void testHashUUIDLenientForNonCanonicalStrings() {
+    String nonCanonical = "1-2-3-4-5";
+    UUID expected = UUID.fromString(nonCanonical);
+
+    byte[] hashResult = HashUtils.hashUUID(new PrimaryKey(new Object[]{nonCanonical}));
+    assertEquals(hashResult.length, 16);
+
+    long msb = 0;
+    long lsb = 0;
+    for (int i = 0; i < 8; i++) {
+      msb = (msb << 8) | (hashResult[i] & 0xFF);
+    }
+    for (int i = 8; i < 16; i++) {
+      lsb = (lsb << 8) | (hashResult[i] & 0xFF);
+    }
+    assertEquals(new UUID(msb, lsb), expected,
+        "hashUUID(\"1-2-3-4-5\") must equal UUID.fromString output for backward compatibility");
+  }
+
+  /**
+   * Multi-column PK regression: each element must independently round-trip through the lenient
+   * {@code UUID.fromString} path. A composite PK mixing one non-canonical and one canonical UUID must
+   * produce a 32-byte concatenation where each 16-byte half matches its corresponding
+   * {@code UUID.fromString} output.
+   */
+  @Test
+  public void testHashUUIDLenientForMultiColumnPrimaryKey() {
+    String nonCanonical = "1-2-3-4-5";
+    String canonical = "550e8400-e29b-41d4-a716-446655440000";
+    UUID expectedFirst = UUID.fromString(nonCanonical);
+    UUID expectedSecond = UUID.fromString(canonical);
+
+    byte[] hashResult = HashUtils.hashUUID(new PrimaryKey(new Object[]{nonCanonical, canonical}));
+    assertEquals(hashResult.length, 32, "Two-column PK must produce 32 bytes (16 per UUID)");
+
+    assertEquals(reconstructUuid(hashResult, 0), expectedFirst,
+        "First half must match UUID.fromString of the non-canonical input");
+    assertEquals(reconstructUuid(hashResult, 16), expectedSecond,
+        "Second half must match UUID.fromString of the canonical input");
+  }
+
+  private static UUID reconstructUuid(byte[] hashBytes, int offset) {
+    long msb = 0;
+    long lsb = 0;
+    for (int i = 0; i < 8; i++) {
+      msb = (msb << 8) | (hashBytes[offset + i] & 0xFF);
+    }
+    for (int i = 0; i < 8; i++) {
+      lsb = (lsb << 8) | (hashBytes[offset + 8 + i] & 0xFF);
+    }
+    return new UUID(msb, lsb);
   }
 
   @Test

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/BloomFilterCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/BloomFilterCreator.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.IndexCreator;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 public interface BloomFilterCreator extends IndexCreator {
@@ -33,6 +34,8 @@ public interface BloomFilterCreator extends IndexCreator {
   default void add(Object value, int dictId) {
     if (getDataType() == FieldSpec.DataType.BYTES) {
       add(BytesUtils.toHexString((byte[]) value));
+    } else if (getDataType() == FieldSpec.DataType.UUID) {
+      add(uuidToCanonicalString(value));
     } else {
       add(value.toString());
     }
@@ -44,11 +47,24 @@ public interface BloomFilterCreator extends IndexCreator {
       for (Object value : values) {
         add(BytesUtils.toHexString((byte[]) value));
       }
+    } else if (getDataType() == FieldSpec.DataType.UUID) {
+      for (Object value : values) {
+        add(uuidToCanonicalString(value));
+      }
     } else {
       for (Object value : values) {
         add(value.toString());
       }
     }
+  }
+
+  /// Renders a UUID value (typically a 16-byte big-endian {@code byte[]} from segment ingest) as its canonical
+  /// lowercase RFC 4122 string. Avoids the defensive byte[] copy that {@code UuidUtils.toBytes(Object)} would
+  /// perform on the {@code byte[]} branch.
+  private static String uuidToCanonicalString(Object value) {
+    return value instanceof byte[]
+        ? UuidUtils.toString((byte[]) value)
+        : UuidUtils.toString(UuidUtils.toBytes(value));
   }
   /**
    * Adds a value to the bloom filter.


### PR DESCRIPTION
## What
Ingest + segment-storage handling for UUID columns.

## Changes
- `DataTypeTransformer` normalizes UUID inputs (canonical string / `java.util.UUID` / `byte[16]`) to 16 bytes
- mutable/immutable dictionaries, fixed-byte MV forward index, stats collectors, min/max, null virtual column, `HashUtils`
- `GenericRow` ser/de, `SegmentProcessorAvroUtils`; Avro `logicalType: "uuid"` interop
- `BloomFilterCreator` (segment-spi)

## Enables
Offline + realtime ingest, dictionary/raw encoding, bloom filters, and UUID-backed upsert primary keys.

## Depends on
PR 1 (`DataType.UUID`, `UuidUtils`).

## Why this PR exists
This is **part 2 of 8** splitting [apache/pinot#18140](https://github.com/apache/pinot/pull/18140) (first-class logical `UUID` type) into reviewable, layered PRs, as requested on that PR.

The split is enabled by the v1 design: `DataType.UUID` has **stored type `BYTES`**, so most code paths handle it automatically; each PR adds explicit UUID semantics to one subsystem.

This PR is **stacked on `01-spi-foundation`** (its base branch), so the diff shown here is **only this layer**.

### Full stack (base → top)
1. `uuid-split/01-spi-foundation` — Add logical UUID type foundation (pinot-spi)
2. `uuid-split/02-ingest-storage` — UUID ingest and segment storage
3. `uuid-split/03-result-rendering` — UUID result rendering (DataSchema, Arrow/JSON encoders)
4. `uuid-split/04-sse-predicates-cast` — UUID server-side predicates, CAST and transforms
5. `uuid-split/05-agg-groupby-distinct` — UUID aggregation, group-by and distinct
6. `uuid-split/06-mse-planner-runtime` — UUID multi-stage engine (planner + runtime)
7. `uuid-split/07-udfs-partitioning` — UUID scalar UDFs and partitioning
8. `uuid-split/08-it-bench-docs` — UUID integration tests, benchmarks and docs

Full feature description, v1 design contract, scope exclusions, and benchmark numbers: [apache/pinot#18140](https://github.com/apache/pinot/pull/18140).
