### PR TITLE
[UUID 4/8] UUID server-side predicates, CAST and transforms

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -23,11 +23,13 @@ import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.PinotDataType;
 
 
@@ -51,6 +53,7 @@ public class FunctionUtils {
       put(Timestamp.class, PinotDataType.TIMESTAMP);
       put(String.class, PinotDataType.STRING);
       put(byte[].class, PinotDataType.BYTES);
+      put(UUID.class, PinotDataType.UUID);
       put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
       put(long[].class, PinotDataType.PRIMITIVE_LONG_ARRAY);
       put(float[].class, PinotDataType.PRIMITIVE_FLOAT_ARRAY);
@@ -60,8 +63,37 @@ public class FunctionUtils {
       put(Timestamp[].class, PinotDataType.TIMESTAMP_ARRAY);
       put(String[].class, PinotDataType.STRING_ARRAY);
       put(byte[][].class, PinotDataType.BYTES_ARRAY);
+      put(UUID[].class, PinotDataType.UUID_ARRAY);
       put(Map.class, PinotDataType.MAP);
       put(Object.class, PinotDataType.OBJECT);
+    }};
+
+  private static final Map<Class<?>, DataType> DATA_TYPE_MAP = new HashMap<>() {{
+      put(int.class, DataType.INT);
+      put(Integer.class, DataType.INT);
+      put(long.class, DataType.LONG);
+      put(Long.class, DataType.LONG);
+      put(float.class, DataType.FLOAT);
+      put(Float.class, DataType.FLOAT);
+      put(double.class, DataType.DOUBLE);
+      put(Double.class, DataType.DOUBLE);
+      put(BigDecimal.class, DataType.BIG_DECIMAL);
+      put(boolean.class, DataType.BOOLEAN);
+      put(Boolean.class, DataType.BOOLEAN);
+      put(Timestamp.class, DataType.TIMESTAMP);
+      put(String.class, DataType.STRING);
+      put(byte[].class, DataType.BYTES);
+      put(UUID.class, DataType.UUID);
+      put(int[].class, DataType.INT);
+      put(long[].class, DataType.LONG);
+      put(float[].class, DataType.FLOAT);
+      put(double[].class, DataType.DOUBLE);
+      put(BigDecimal[].class, DataType.BIG_DECIMAL);
+      put(boolean[].class, DataType.BOOLEAN);
+      put(Timestamp[].class, DataType.TIMESTAMP);
+      put(String[].class, DataType.STRING);
+      put(byte[][].class, DataType.BYTES);
+      put(UUID[].class, DataType.UUID);
     }};
 
   private static final Map<Class<?>, ColumnDataType> COLUMN_DATA_TYPE_MAP = new HashMap<>() {{
@@ -79,6 +111,7 @@ public class FunctionUtils {
       put(Timestamp.class, ColumnDataType.TIMESTAMP);
       put(String.class, ColumnDataType.STRING);
       put(byte[].class, ColumnDataType.BYTES);
+      put(UUID.class, ColumnDataType.UUID);
       put(int[].class, ColumnDataType.INT_ARRAY);
       put(long[].class, ColumnDataType.LONG_ARRAY);
       put(float[].class, ColumnDataType.FLOAT_ARRAY);
@@ -88,6 +121,7 @@ public class FunctionUtils {
       put(Timestamp[].class, ColumnDataType.TIMESTAMP_ARRAY);
       put(String[].class, ColumnDataType.STRING_ARRAY);
       put(byte[][].class, ColumnDataType.BYTES_ARRAY);
+      put(UUID[].class, ColumnDataType.UUID_ARRAY);
       put(Object.class, ColumnDataType.OBJECT);
     }};
 
@@ -151,6 +185,14 @@ public class FunctionUtils {
   }
 
   /**
+   * Returns the corresponding DataType for the given class, or {@code null} if there is no one matching.
+   */
+  @Nullable
+  public static DataType getDataType(Class<?> clazz) {
+    return DATA_TYPE_MAP.get(clazz);
+  }
+
+  /**
    * Returns the corresponding ColumnDataType for the given class, or {@code null} if there is no one matching.
    */
   @Nullable
@@ -184,6 +226,8 @@ public class FunctionUtils {
       case STRING:
       case JSON:
         return typeFactory.createSqlType(SqlTypeName.VARCHAR);
+      case UUID:
+        return typeFactory.createSqlType(SqlTypeName.UUID);
       case BYTES:
         return typeFactory.createSqlType(SqlTypeName.VARBINARY);
       case INT_ARRAY:
@@ -204,6 +248,8 @@ public class FunctionUtils {
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.VARCHAR), -1);
       case BYTES_ARRAY:
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.VARBINARY), -1);
+      case UUID_ARRAY:
+        return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.UUID), -1);
       default:
         return typeFactory.createSqlType(SqlTypeName.OTHER);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -171,6 +171,9 @@ public class LiteralContext {
         return PinotDataType.BIG_DECIMAL;
       case STRING:
         return singleValue ? PinotDataType.STRING : PinotDataType.STRING_ARRAY;
+      case UUID:
+        Preconditions.checkState(singleValue, "UUID array is not supported");
+        return PinotDataType.UUID;
       default:
         throw new IllegalStateException("Unsupported DataType: " + type);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pinot.common.request.context;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
@@ -41,12 +45,18 @@ import org.apache.pinot.common.request.context.predicate.VectorSimilarityRadiusP
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 
 
 public class RequestContextUtils {
+  private static final String UNSUPPORTED_RHS_MESSAGE =
+      "Pinot does not support column or function on the right-hand side of the predicate";
+
   private RequestContextUtils() {
   }
 
@@ -128,6 +138,51 @@ public class RequestContextUtils {
       default:
         throw new IllegalStateException();
     }
+  }
+
+  /**
+   * Returns {@code true} when the expression can be reduced to a literal value without accessing columns.
+   *
+   * <p>Implementation note: the shape check below runs for every comparison predicate of every query, so it must
+   * not be exception-driven — identifiers and unsupported functions (the overwhelmingly common case) return
+   * {@code false} without constructing a throwable. Only expressions that pass the shape check (literals composed
+   * through the foldable function set) are actually evaluated, where a failure means invalid literal values
+   * (e.g., {@code TO_UUID('garbage')}) rather than a non-literal expression.
+   */
+  public static boolean canEvaluateLiteral(Expression thriftExpression) {
+    if (!isFoldableLiteralShape(thriftExpression)) {
+      return false;
+    }
+    try {
+      evaluateLiteralValue(thriftExpression);
+      return true;
+    } catch (BadQueryRequestException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Cheap, non-throwing structural check: literals are foldable; function calls are foldable only when the
+   * canonical operator is in {@link #FOLDABLE_RHS_FUNCTIONS} and all operands are recursively foldable.
+   * Identifiers (and anything else) are not.
+   */
+  private static boolean isFoldableLiteralShape(Expression thriftExpression) {
+    if (thriftExpression.getLiteral() != null) {
+      return true;
+    }
+    Function function = thriftExpression.getFunctionCall();
+    if (function == null) {
+      return false;
+    }
+    if (!FOLDABLE_RHS_FUNCTIONS.contains(FunctionRegistry.canonicalize(function.getOperator()))) {
+      return false;
+    }
+    for (Expression operand : function.getOperands()) {
+      if (!isFoldableLiteralShape(operand)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static FilterContext getFilterInner(Function thriftFunction) {
@@ -217,23 +272,23 @@ public class RequestContextUtils {
       case GREATER_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), false, getStringValue(operands.get(1)), false,
-                RangePredicate.UNBOUNDED, new LiteralContext(operands.get(1).getLiteral()).getType()));
+                RangePredicate.UNBOUNDED, getLiteralType(operands.get(1))));
       case GREATER_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), true, getStringValue(operands.get(1)), false,
-                RangePredicate.UNBOUNDED, new LiteralContext(operands.get(1).getLiteral()).getType()));
+                RangePredicate.UNBOUNDED, getLiteralType(operands.get(1))));
       case LESS_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), false, RangePredicate.UNBOUNDED, false,
-                getStringValue(operands.get(1)), new LiteralContext(operands.get(1).getLiteral()).getType()));
+                getStringValue(operands.get(1)), getLiteralType(operands.get(1))));
       case LESS_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), false, RangePredicate.UNBOUNDED, true,
-                getStringValue(operands.get(1)), new LiteralContext(operands.get(1).getLiteral()).getType()));
+                getStringValue(operands.get(1)), getLiteralType(operands.get(1))));
       case BETWEEN:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), true, getStringValue(operands.get(1)), true,
-                getStringValue(operands.get(2)), new LiteralContext(operands.get(1).getLiteral()).getType()));
+                getStringValue(operands.get(2)), getLiteralType(operands.get(1))));
       case RANGE:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -287,12 +342,7 @@ public class RequestContextUtils {
   }
 
   public static String getStringValue(Expression thriftExpression) {
-    Literal literal = thriftExpression.getLiteral();
-    if (literal == null) {
-      throw new BadQueryRequestException(
-          "Pinot does not support column or function on the right-hand side of the predicate");
-    }
-    return RequestUtils.getLiteralString(literal);
+    return evaluateLiteralValue(thriftExpression).getStringValue();
   }
 
   /**
@@ -411,23 +461,23 @@ public class RequestContextUtils {
       case GREATER_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), false, getStringValue(operands.get(1)), false, RangePredicate.UNBOUNDED,
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case GREATER_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), true, getStringValue(operands.get(1)), false, RangePredicate.UNBOUNDED,
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case LESS_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), false, RangePredicate.UNBOUNDED, false, getStringValue(operands.get(1)),
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case LESS_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), false, RangePredicate.UNBOUNDED, true, getStringValue(operands.get(1)),
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case BETWEEN:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), true, getStringValue(operands.get(1)), true,
-                getStringValue(operands.get(2)), operands.get(1).getLiteral().getType()));
+                getStringValue(operands.get(2)), getLiteralType(operands.get(1))));
       case RANGE:
         return FilterContext.forPredicate(new RangePredicate(operands.get(0), getStringValue(operands.get(1))));
       case REGEXP_LIKE:
@@ -478,11 +528,222 @@ public class RequestContextUtils {
   //       literal context doesn't support float, and we cannot differentiate explicit string literal and literal
   //       without explicit type, so we always convert the literal into string.
   private static String getStringValue(ExpressionContext expressionContext) {
-    if (expressionContext.getType() != ExpressionContext.Type.LITERAL) {
-      throw new BadQueryRequestException(
-          "Pinot does not support column or function on the right-hand side of the predicate");
+    return evaluateLiteralValue(expressionContext).getStringValue();
+  }
+
+  private static DataType getLiteralType(Expression thriftExpression) {
+    return evaluateLiteralValue(thriftExpression).getType();
+  }
+
+  private static DataType getLiteralType(ExpressionContext expressionContext) {
+    return evaluateLiteralValue(expressionContext).getType();
+  }
+
+  private static EvaluatedLiteralValue evaluateLiteralValue(Expression thriftExpression) {
+    Literal literal = thriftExpression.getLiteral();
+    if (literal != null) {
+      return fromLiteralContext(new LiteralContext(literal));
     }
-    return expressionContext.getLiteral().getStringValue();
+    Function function = thriftExpression.getFunctionCall();
+    if (function != null) {
+      return evaluateFunctionLiteral(function.getOperator(), function.getOperands(),
+          RequestContextUtils::evaluateLiteralValue);
+    }
+    throw new BadQueryRequestException(UNSUPPORTED_RHS_MESSAGE);
+  }
+
+  private static EvaluatedLiteralValue evaluateLiteralValue(ExpressionContext expressionContext) {
+    if (expressionContext.getType() == ExpressionContext.Type.LITERAL) {
+      return fromLiteralContext(expressionContext.getLiteral());
+    }
+    if (expressionContext.getType() == ExpressionContext.Type.FUNCTION) {
+      FunctionContext function = expressionContext.getFunction();
+      return evaluateFunctionLiteral(function.getFunctionName(), function.getArguments(),
+          RequestContextUtils::evaluateLiteralValue);
+    }
+    throw new BadQueryRequestException(UNSUPPORTED_RHS_MESSAGE);
+  }
+
+  // NOTE: This set and the switch in evaluateFunctionLiteral together hard-code the functions that can appear on
+  // the RHS of a predicate literal (e.g., WHERE col = TO_UUID('...')). If new UUID-related or other
+  // constant-folding functions are added (see ToUuidScalarFunction, UuidConversionFunctions in pinot-common),
+  // add the canonical name here AND the corresponding case to the switch. RequestContextUtilsTest's drift guard
+  // asserts this set stays in sync with the registered deterministic UUID scalar functions.
+  @VisibleForTesting
+  static final Set<String> FOLDABLE_RHS_FUNCTIONS =
+      Set.of("cast", "touuid", "uuidtobytes", "bytestouuid", "uuidtostring", "isuuid", "uuidversion",
+          "uuidtimestamp");
+
+  private static <T> EvaluatedLiteralValue evaluateFunctionLiteral(String functionName, List<T> operands,
+      java.util.function.Function<T, EvaluatedLiteralValue> evaluator) {
+    String canonicalName = FunctionRegistry.canonicalize(functionName);
+    switch (canonicalName) {
+      case "cast": {
+        validateFunctionArity("CAST", operands, 2);
+        EvaluatedLiteralValue source = evaluator.apply(operands.get(0));
+        EvaluatedLiteralValue target = evaluator.apply(operands.get(1));
+        return evaluateCastLiteral(source, getCastTargetType(target.getStringValue()));
+      }
+      case "touuid":
+        validateFunctionArity("TO_UUID", operands, 1);
+        return evaluateToUuidLiteral(evaluator.apply(operands.get(0)));
+      case "uuidtobytes":
+        validateFunctionArity("UUID_TO_BYTES", operands, 1);
+        return evaluateUuidToBytesLiteral(evaluator.apply(operands.get(0)));
+      case "bytestouuid":
+        validateFunctionArity("BYTES_TO_UUID", operands, 1);
+        return evaluateBytesToUuidLiteral(evaluator.apply(operands.get(0)));
+      case "uuidtostring":
+        validateFunctionArity("UUID_TO_STRING", operands, 1);
+        return evaluateUuidToStringLiteral(evaluator.apply(operands.get(0)));
+      case "isuuid":
+        validateFunctionArity("IS_UUID", operands, 1);
+        return evaluateIsUuidLiteral(evaluator.apply(operands.get(0)));
+      case "uuidversion":
+        validateFunctionArity("UUID_VERSION", operands, 1);
+        return evaluateUuidVersionLiteral(evaluator.apply(operands.get(0)));
+      case "uuidtimestamp":
+        validateFunctionArity("UUID_TIMESTAMP", operands, 1);
+        return evaluateUuidTimestampLiteral(evaluator.apply(operands.get(0)));
+      default:
+        throw new BadQueryRequestException(UNSUPPORTED_RHS_MESSAGE);
+    }
+  }
+
+  private static EvaluatedLiteralValue evaluateCastLiteral(EvaluatedLiteralValue source, DataType targetType) {
+    if (source.getType() == DataType.UNKNOWN) {
+      return new EvaluatedLiteralValue(source.getStringValue(), targetType);
+    }
+
+    if (targetType == DataType.UUID) {
+      return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.UUID);
+    }
+    if (targetType == DataType.STRING && source.getType() == DataType.UUID) {
+      return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.STRING);
+    }
+    if (targetType == DataType.BYTES && source.getType() == DataType.UUID) {
+      return new EvaluatedLiteralValue(BytesUtils.toHexString(UuidUtils.toBytes(convertToCanonicalUuidString(source))),
+          DataType.BYTES);
+    }
+
+    Object converted = targetType.convert(source.getStringValue());
+    return new EvaluatedLiteralValue(targetType.toString(converted), targetType);
+  }
+
+  private static EvaluatedLiteralValue evaluateToUuidLiteral(EvaluatedLiteralValue source) {
+    return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.UUID);
+  }
+
+  private static EvaluatedLiteralValue evaluateUuidToBytesLiteral(EvaluatedLiteralValue source) {
+    Preconditions.checkArgument(source.getType() == DataType.UUID, "UUID_TO_BYTES requires a UUID operand");
+    return new EvaluatedLiteralValue(BytesUtils.toHexString(UuidUtils.toBytes(source.getStringValue())),
+        DataType.BYTES);
+  }
+
+  private static EvaluatedLiteralValue evaluateBytesToUuidLiteral(EvaluatedLiteralValue source) {
+    Preconditions.checkArgument(source.getType() == DataType.BYTES, "BYTES_TO_UUID requires a BYTES operand");
+    return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.UUID);
+  }
+
+  private static EvaluatedLiteralValue evaluateUuidToStringLiteral(EvaluatedLiteralValue source) {
+    Preconditions.checkArgument(source.getType() == DataType.UUID, "UUID_TO_STRING requires a UUID operand");
+    return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.STRING);
+  }
+
+  private static EvaluatedLiteralValue evaluateUuidVersionLiteral(EvaluatedLiteralValue source) {
+    if (source.getType() == DataType.UNKNOWN) {
+      return new EvaluatedLiteralValue(source.getStringValue(), DataType.INT);
+    }
+    int version = UuidUtils.getVersion(UuidUtils.toUUID(convertToCanonicalUuidString(source)));
+    return new EvaluatedLiteralValue(Integer.toString(version), DataType.INT);
+  }
+
+  private static EvaluatedLiteralValue evaluateUuidTimestampLiteral(EvaluatedLiteralValue source) {
+    if (source.getType() == DataType.UNKNOWN) {
+      return new EvaluatedLiteralValue(source.getStringValue(), DataType.LONG);
+    }
+    long ts = UuidUtils.getTimestampMillis(UuidUtils.toUUID(convertToCanonicalUuidString(source)));
+    return new EvaluatedLiteralValue(Long.toString(ts), DataType.LONG);
+  }
+
+  private static EvaluatedLiteralValue evaluateIsUuidLiteral(EvaluatedLiteralValue source) {
+    boolean isUuid;
+    switch (source.getType()) {
+      case STRING:
+        isUuid = UuidUtils.isUuid(source.getStringValue());
+        break;
+      case BYTES:
+        isUuid = UuidUtils.isUuid(BytesUtils.toBytes(source.getStringValue()));
+        break;
+      case UUID:
+        isUuid = true;
+        break;
+      case UNKNOWN:
+        isUuid = false;
+        break;
+      default:
+        throw new IllegalArgumentException("IS_UUID only supports STRING, BYTES, or UUID operands");
+    }
+    return new EvaluatedLiteralValue(Boolean.toString(isUuid), DataType.BOOLEAN);
+  }
+
+  private static String convertToCanonicalUuidString(EvaluatedLiteralValue source) {
+    switch (source.getType()) {
+      case STRING:
+      case UUID:
+        return UuidUtils.toString(UuidUtils.toBytes(source.getStringValue()));
+      case BYTES:
+        return UuidUtils.toString(BytesUtils.toBytes(source.getStringValue()));
+      default:
+        throw new IllegalArgumentException("Cannot convert " + source.getType() + " literal to UUID");
+    }
+  }
+
+  private static DataType getCastTargetType(String targetTypeString) {
+    switch (targetTypeString.toUpperCase(Locale.ROOT)) {
+      case "INT":
+      case "INTEGER":
+        return DataType.INT;
+      case "LONG":
+      case "BIGINT":
+        return DataType.LONG;
+      case "FLOAT":
+        return DataType.FLOAT;
+      case "DOUBLE":
+        return DataType.DOUBLE;
+      case "DECIMAL":
+      case "BIGDECIMAL":
+      case "BIG_DECIMAL":
+        return DataType.BIG_DECIMAL;
+      case "BOOL":
+      case "BOOLEAN":
+        return DataType.BOOLEAN;
+      case "TIMESTAMP":
+        return DataType.TIMESTAMP;
+      case "STRING":
+      case "VARCHAR":
+        return DataType.STRING;
+      case "JSON":
+        return DataType.JSON;
+      case "BYTES":
+      case "VARBINARY":
+        return DataType.BYTES;
+      case "UUID":
+        return DataType.UUID;
+      default:
+        throw new BadQueryRequestException("Unable to cast expression to type - " + targetTypeString);
+    }
+  }
+
+  private static void validateFunctionArity(String functionName, List<?> operands, int expectedArity) {
+    if (operands.size() != expectedArity) {
+      throw new BadQueryRequestException(functionName + " function must have exactly " + expectedArity + " operand"
+          + (expectedArity == 1 ? "" : "s"));
+    }
+  }
+
+  private static EvaluatedLiteralValue fromLiteralContext(LiteralContext literalContext) {
+    return new EvaluatedLiteralValue(literalContext.getStringValue(), literalContext.getType());
   }
 
   private static float[] getVectorValue(ExpressionContext expressionContext) {
@@ -570,6 +831,24 @@ public class RequestContextUtils {
         return (float) literal.getDoubleValue();
       default:
         throw new IllegalStateException("Unsupported literal type: " + type);
+    }
+  }
+
+  private static final class EvaluatedLiteralValue {
+    private final String _stringValue;
+    private final DataType _type;
+
+    private EvaluatedLiteralValue(String stringValue, DataType type) {
+      _stringValue = stringValue;
+      _type = type;
+    }
+
+    private String getStringValue() {
+      return _stringValue;
+    }
+
+    private DataType getType() {
+      return _type;
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
@@ -25,6 +25,7 @@ import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -42,6 +43,7 @@ public abstract class BaseInPredicate extends BasePredicate {
   private int[] _booleanValues;
   private long[] _timestampValues;
   private ByteArray[] _bytesValues;
+  private ByteArray[] _uuidValues;
 
   public BaseInPredicate(ExpressionContext lhs, List<String> values) {
     super(lhs);
@@ -154,5 +156,18 @@ public abstract class BaseInPredicate extends BasePredicate {
       _bytesValues = bigDecimalValues;
     }
     return bigDecimalValues;
+  }
+
+  public ByteArray[] getUuidValues() {
+    ByteArray[] uuidValues = _uuidValues;
+    if (uuidValues == null) {
+      int numValues = _values.size();
+      uuidValues = new ByteArray[numValues];
+      for (int i = 0; i < numValues; i++) {
+        uuidValues[i] = new ByteArray(UuidUtils.toBytes(_values.get(i)));
+      }
+      _uuidValues = uuidValues;
+    }
+    return uuidValues;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -104,10 +105,12 @@ public class PredicateComparisonRewriter implements QueryRewriter {
         case LESS_THAN_OR_EQUAL:
           Expression firstOperand = operands.get(0);
           Expression secondOperand = operands.get(1);
+          boolean firstOperandIsLiteral = RequestContextUtils.canEvaluateLiteral(firstOperand);
+          boolean secondOperandIsLiteral = RequestContextUtils.canEvaluateLiteral(secondOperand);
 
           // Handle predicate like '10 = a' -> 'a = 10'
-          if (firstOperand.isSetLiteral()) {
-            if (!secondOperand.isSetLiteral()) {
+          if (firstOperandIsLiteral) {
+            if (!secondOperandIsLiteral) {
               function.setOperator(getOppositeOperator(filterKind).name());
               operands.set(0, secondOperand);
               operands.set(1, firstOperand);
@@ -116,7 +119,7 @@ public class PredicateComparisonRewriter implements QueryRewriter {
           }
 
           // Handle predicate like 'a > b' -> 'a - b > 0'
-          if (!secondOperand.isSetLiteral()) {
+          if (!secondOperandIsLiteral) {
             Expression minusExpression = RequestUtils.getFunctionExpression("minus", firstOperand, secondOperand);
             operands.set(0, minusExpression);
             operands.set(1, RequestUtils.getLiteralExpression(0));
@@ -176,7 +179,7 @@ public class PredicateComparisonRewriter implements QueryRewriter {
         default:
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (!operands.get(i).isSetLiteral()) {
+            if (!RequestContextUtils.canEvaluateLiteral(operands.get(i))) {
               throw new SqlCompilationException(
                   String.format("For %s predicate, the operands except for the first one must be literal, got: %s",
                       filterKind, expression));

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
@@ -25,7 +25,10 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.Test;
 
@@ -154,5 +157,22 @@ public class FunctionUtilsTest {
     assertEquals(FunctionUtils.getColumnDataType(Object.class), ColumnDataType.OBJECT);
     // Unknown class
     assertNull(FunctionUtils.getColumnDataType(LocalDate.class));
+  }
+
+  @Test
+  public void testUUIDMappings() {
+    assertEquals(FunctionUtils.getParameterType(UUID.class), PinotDataType.UUID);
+    assertEquals(FunctionUtils.getArgumentType(UUID.randomUUID()), PinotDataType.UUID);
+    assertEquals(FunctionUtils.getDataType(UUID.class), DataType.UUID);
+    assertEquals(FunctionUtils.getDataType(UUID[].class), DataType.UUID);
+    assertEquals(FunctionUtils.getColumnDataType(UUID.class), ColumnDataType.UUID);
+    assertEquals(FunctionUtils.getRelDataType(new JavaTypeFactoryImpl(), UUID.class).getSqlTypeName(),
+        SqlTypeName.UUID);
+    assertEquals(FunctionUtils.getParameterType(UUID[].class), PinotDataType.UUID_ARRAY);
+    assertEquals(FunctionUtils.getArgumentType(new UUID[]{UUID.randomUUID()}), PinotDataType.UUID_ARRAY);
+    assertEquals(FunctionUtils.getDataType(UUID[].class), DataType.UUID);
+    assertEquals(FunctionUtils.getColumnDataType(UUID[].class), ColumnDataType.UUID_ARRAY);
+    assertEquals(FunctionUtils.getRelDataType(new JavaTypeFactoryImpl(), UUID[].class).getComponentType()
+        .getSqlTypeName(), SqlTypeName.UUID);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
@@ -25,6 +25,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -221,5 +222,17 @@ public class LiteralContextTest {
     assertEquals(literalContext.getBytesValue(), BytesUtils.toBytes("deadbeef"));
     assertFalse(literalContext.isNull());
     assertEquals(literalContext.toString(), "'deadbeef'");
+  }
+
+  @Test
+  public void testUuidLiteral() {
+    String mixedCaseUuid = "550E8400-E29B-41D4-A716-446655440000";
+    String canonicalUuid = "550e8400-e29b-41d4-a716-446655440000";
+    LiteralContext literalContext = new LiteralContext(DataType.UUID, mixedCaseUuid);
+
+    assertEquals(literalContext.getStringValue(), canonicalUuid);
+    assertEquals(literalContext.getBytesValue(), UuidUtils.toBytes(canonicalUuid));
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'" + canonicalUuid + "'");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/RequestContextUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/RequestContextUtilsTest.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.request.context;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.common.request.context.predicate.InPredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests filter conversion for literal-only expressions on the right-hand side.
+ */
+public class RequestContextUtilsTest {
+  private static final String UUID_1 = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String UUID_2 = "550e8400-e29b-41d4-a716-446655440001";
+
+  @Test
+  public void testGetFilterWithUuidCastLiteralRhs() {
+    FilterContext filter =
+        RequestContextUtils.getFilter(CalciteSqlParser.compileToExpression("uuidCol = CAST('" + UUID_1 + "' AS UUID)"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValue(), UUID_1);
+  }
+
+  @Test
+  public void testGetFilterExpressionContextWithUuidCastLiteralIn() {
+    FilterContext filter = RequestContextUtils.getFilter(
+        RequestContextUtils.getExpression("uuidCol IN (CAST('" + UUID_1 + "' AS UUID), CAST('" + UUID_2 + "' AS UUID))"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    InPredicate predicate = (InPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValues(), List.of(UUID_1, UUID_2));
+  }
+
+  @Test
+  public void testGetFilterWithToUuidLiteralRhsNormalizesCase() {
+    FilterContext filter = RequestContextUtils.getFilter(
+        CalciteSqlParser.compileToExpression("uuidCol = TO_UUID('550E8400-E29B-41D4-A716-446655440000')"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValue(), UUID_1);
+  }
+
+  @Test
+  public void testGetFilterWithUuidToBytesNestedLiteralRhs() {
+    FilterContext filter = RequestContextUtils.getFilter(
+        CalciteSqlParser.compileToExpression("bytesCol = UUID_TO_BYTES(CAST('" + UUID_1 + "' AS UUID))"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "bytesCol");
+    Assert.assertEquals(predicate.getValue(), BytesUtils.toHexString(UuidUtils.toBytes(UUID_1)));
+  }
+
+  @Test
+  public void testGetFilterWithBytesToUuidNestedLiteralRhs() {
+    String bytesLiteral = BytesUtils.toHexString(UuidUtils.toBytes(UUID_2));
+    FilterContext filter = RequestContextUtils.getFilter(
+        CalciteSqlParser.compileToExpression("uuidCol = BYTES_TO_UUID(CAST('" + bytesLiteral + "' AS BYTES))"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValue(), UUID_2);
+  }
+
+  @Test
+  public void testUuidCastLiteralUsesLocaleIndependentTypeParsing() {
+    Locale originalDefault = Locale.getDefault();
+    Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+    try {
+      FilterContext filter = RequestContextUtils.getFilter(
+          CalciteSqlParser.compileToExpression("uuidCol = CAST('" + UUID_1 + "' AS uuid)"));
+
+      Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+      EqPredicate predicate = (EqPredicate) filter.getPredicate();
+      Assert.assertEquals(predicate.getValue(), UUID_1);
+    } finally {
+      Locale.setDefault(originalDefault);
+    }
+  }
+
+  @Test
+  public void testInvalidUuidFunctionArityThrowsBadQueryRequest() {
+    FunctionContext castFunction = new FunctionContext(FunctionContext.Type.TRANSFORM, "cast",
+        List.of(ExpressionContext.forLiteral(DataType.STRING, UUID_1)));
+    ExpressionContext filterExpression = ExpressionContext.forFunction(
+        new FunctionContext(FunctionContext.Type.TRANSFORM, "equals",
+            List.of(ExpressionContext.forIdentifier("uuidCol"), ExpressionContext.forFunction(castFunction))));
+
+    BadQueryRequestException exception =
+        Assert.expectThrows(BadQueryRequestException.class, () -> RequestContextUtils.getFilter(filterExpression));
+    Assert.assertEquals(exception.getMessage(), "CAST function must have exactly 2 operands");
+  }
+
+  /**
+   * Drift guard: {@link RequestContextUtils#evaluateFunctionLiteral} hard-codes the set of UUID-related scalar
+   * functions that may appear on the RHS of a predicate literal. If a new deterministic UUID scalar function is
+   * added via {@code @ScalarFunction} under {@code org.apache.pinot.common.function.scalar.uuid} but the switch
+   * is not updated, queries like {@code col = NEW_UUID_FN(...)} would silently fail with the generic "unsupported
+   * RHS" error. This test fails fast in that scenario so the author is forced to extend the switch.
+   *
+   * <p>Non-deterministic UUID generators ({@code UUID_V4}, {@code UUID_V7}) are intentionally excluded — their
+   * results cannot be folded to a constant RHS.
+   */
+  @Test
+  public void testEvaluateFunctionLiteralCoversAllDeterministicUuidScalarFunctions() {
+    // The production shape pre-filter (canEvaluateLiteral) and the evaluateFunctionLiteral switch are both driven
+    // by FOLDABLE_RHS_FUNCTIONS. Validate against the production set directly so drift between the set and the
+    // registered scalar functions is caught here.
+    Set<String> supportedByRhsEvaluator = RequestContextUtils.FOLDABLE_RHS_FUNCTIONS;
+    Assert.assertTrue(supportedByRhsEvaluator.containsAll(
+        Set.of("cast", "touuid", "uuidtobytes", "bytestouuid", "uuidtostring", "isuuid", "uuidversion",
+            "uuidtimestamp")),
+        "FOLDABLE_RHS_FUNCTIONS lost a name the evaluateFunctionLiteral switch handles");
+
+    // Sweep var-arg plus arities 0..8 so a higher-arity UUID function added in future (e.g., UUID_FROM_PARTS(msb,
+    // lsb, version)) still gets considered by the drift guard. UUID_V4/UUID_V7 are registered with
+    // isDeterministic=false and are correctly excluded.
+    int[] aritiesToCheck = {FunctionRegistry.VAR_ARG_KEY, 0, 1, 2, 3, 4, 5, 6, 7, 8};
+    Set<String> registeredDeterministicUuidFunctions = FunctionRegistry.getFunctions().entrySet().stream()
+        // canonical names from FunctionRegistry are already lowercased and underscore-stripped
+        .filter(e -> e.getKey().startsWith("uuid") || "touuid".equals(e.getKey()) || "isuuid".equals(e.getKey()))
+        .filter(e -> {
+          for (int arity : aritiesToCheck) {
+            FunctionInfo info = e.getValue().getFunctionInfo(arity);
+            if (info != null && info.isDeterministic()) {
+              return true;
+            }
+          }
+          return false;
+        })
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+
+    Set<String> missingFromEvaluator = registeredDeterministicUuidFunctions.stream()
+        .filter(name -> !supportedByRhsEvaluator.contains(name))
+        .collect(Collectors.toSet());
+    Assert.assertTrue(missingFromEvaluator.isEmpty(),
+        "Deterministic UUID scalar functions registered in FunctionRegistry but not handled by "
+            + "RequestContextUtils#evaluateFunctionLiteral switch: " + missingFromEvaluator
+            + ". Either add the corresponding case to the switch, or — if the function genuinely cannot be folded "
+            + "to a constant RHS — annotate it with isDeterministic=false in its @ScalarFunction.");
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2823,6 +2823,23 @@ public class CalciteSqlCompilerTest {
     expression = CompileTimeFunctionsInvoker.invokeCompileTimeFunctionExpression(expression);
     Assert.assertNotNull(expression.getLiteral());
     Assert.assertFalse(expression.getLiteral().getBoolValue());
+
+    // UUID_V4() / UUID_V7() are non-deterministic; the broker MUST NOT fold them into a single literal that
+    // every row would then reuse. Annotated as @ScalarFunction(isDeterministic = false), so the expression
+    // must remain a function call after going through the compile-time invoker.
+    expression = compileToExpression("uuidV4()");
+    Assert.assertNotNull(expression.getFunctionCall());
+    expression = CompileTimeFunctionsInvoker.invokeCompileTimeFunctionExpression(expression);
+    Assert.assertNotNull(expression.getFunctionCall(),
+        "UUID_V4() must remain a function call after compile-time evaluation, not be folded to a literal");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "uuidv4");
+
+    expression = compileToExpression("uuidV7()");
+    Assert.assertNotNull(expression.getFunctionCall());
+    expression = CompileTimeFunctionsInvoker.invokeCompileTimeFunctionExpression(expression);
+    Assert.assertNotNull(expression.getFunctionCall(),
+        "UUID_V7() must remain a function call after compile-time evaluation, not be folded to a literal");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "uuidv7");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
@@ -179,4 +179,66 @@ public class PredicateComparisonRewriterTest {
         CalciteSqlParser.compileToPinotQueryWithoutRewrites("SELECT * FROM mytable WHERE col1 BETWEEN col2 AND col3");
     assertThrows(SqlCompilationException.class, () -> _predicateComparisonRewriter.rewrite(betweenQuery));
   }
+
+  @Test
+  public void testUuidComparisonWithLiteralFunctionRhsIsNotRewrittenToMinus() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE uuidCol = CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID)");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase(), "cast");
+  }
+
+  @Test
+  public void testUuidComparisonWithLiteralFunctionLhsIsSwapped() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE TO_UUID('550e8400-e29b-41d4-a716-446655440000') = uuidCol");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    String operator =
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase();
+    Assert.assertTrue(operator.equals("touuid") || operator.equals("to_uuid"), operator);
+  }
+
+  @Test
+  public void testUuidInPredicateAcceptsLiteralFunctions() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE uuidCol IN (CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID),"
+            + " TO_UUID('550e8400-e29b-41d4-a716-446655440001'))");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "IN");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase(), "cast");
+    String operator =
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(2).getFunctionCall().getOperator()
+            .toLowerCase();
+    Assert.assertTrue(operator.equals("touuid") || operator.equals("to_uuid"), operator);
+  }
+
+  @Test
+  public void testUuidNotInPredicateAcceptsLiteralFunctions() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE uuidCol NOT IN (CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID))");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "NOT_IN");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase(), "cast");
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -29,8 +29,10 @@ import org.apache.pinot.core.operator.filter.predicate.traits.LongValue;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -82,6 +84,8 @@ public class EqualsPredicateEvaluatorFactory {
         return new StringRawValueBasedEqPredicateEvaluator(eqPredicate, value);
       case BYTES:
         return new BytesRawValueBasedEqPredicateEvaluator(eqPredicate, BytesUtils.toBytes(value));
+      case UUID:
+        return new BytesRawValueBasedEqPredicateEvaluator(eqPredicate, UuidUtils.toBytes(value), DataType.UUID);
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }
@@ -93,8 +97,12 @@ public class EqualsPredicateEvaluatorFactory {
 
     DictionaryBasedEqPredicateEvaluator(EqPredicate eqPredicate, Dictionary dictionary, DataType dataType) {
       super(eqPredicate, dictionary);
-      String predicateValue = PredicateUtils.getStoredValue(eqPredicate.getValue(), dataType);
-      _matchingDictId = dictionary.indexOf(predicateValue);
+      if (dataType == DataType.UUID) {
+        _matchingDictId = dictionary.indexOf(new ByteArray(UuidUtils.toBytes(eqPredicate.getValue())));
+      } else {
+        String predicateValue = PredicateUtils.getStoredValue(eqPredicate.getValue(), dataType);
+        _matchingDictId = dictionary.indexOf(predicateValue);
+      }
       if (_matchingDictId >= 0) {
         _matchingDictIds = new int[]{_matchingDictId};
         if (dictionary.length() == 1) {
@@ -417,10 +425,16 @@ public class EqualsPredicateEvaluatorFactory {
 
   private static final class BytesRawValueBasedEqPredicateEvaluator extends EqRawPredicateEvaluator {
     final byte[] _matchingValue;
+    final DataType _dataType;
 
     BytesRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, byte[] matchingValue) {
+      this(eqPredicate, matchingValue, DataType.BYTES);
+    }
+
+    BytesRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, byte[] matchingValue, DataType dataType) {
       super(eqPredicate);
       _matchingValue = matchingValue;
+      _dataType = dataType;
     }
 
     @Override
@@ -435,7 +449,7 @@ public class EqualsPredicateEvaluatorFactory {
 
     @Override
     public DataType getDataType() {
-      return DataType.BYTES;
+      return _dataType;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 
 
 /**
@@ -149,6 +150,14 @@ public class InPredicateEvaluatorFactory {
           matchingValues.add(value);
         }
         return new BytesRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
+      }
+      case UUID: {
+        ByteArray[] uuidValues = inPredicate.getUuidValues();
+        Set<UuidKey> matchingValues = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(uuidValues.length));
+        for (ByteArray value : uuidValues) {
+          matchingValues.add(UuidKey.fromByteArray(value));
+        }
+        return new UuidRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
       }
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
@@ -488,6 +497,39 @@ public class InPredicateEvaluatorFactory {
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.visitBytes(_matchingValues);
+    }
+  }
+
+  private static final class UuidRawValueBasedInPredicateEvaluator extends InRawPredicateEvaluator {
+    final Set<UuidKey> _matchingValues;
+
+    UuidRawValueBasedInPredicateEvaluator(InPredicate inPredicate, Set<UuidKey> matchingValues) {
+      super(inPredicate);
+      _matchingValues = matchingValues;
+    }
+
+    @Override
+    public int getNumMatchingItems() {
+      return _matchingValues.size();
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.UUID;
+    }
+
+    @Override
+    public boolean applySV(byte[] value) {
+      return _matchingValues.contains(UuidKey.fromBytes(value));
+    }
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      Set<ByteArray> matchingByteArrays = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(_matchingValues.size()));
+      for (UuidKey matchingValue : _matchingValues) {
+        matchingByteArrays.add(matchingValue.toByteArray());
+      }
+      return visitor.visitBytes(matchingByteArrays);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -25,8 +25,10 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -78,6 +80,8 @@ public class NotEqualsPredicateEvaluatorFactory {
         return new StringRawValueBasedNeqPredicateEvaluator(notEqPredicate, value);
       case BYTES:
         return new BytesRawValueBasedNeqPredicateEvaluator(notEqPredicate, BytesUtils.toBytes(value));
+      case UUID:
+        return new BytesRawValueBasedNeqPredicateEvaluator(notEqPredicate, UuidUtils.toBytes(value), DataType.UUID);
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }
@@ -88,8 +92,12 @@ public class NotEqualsPredicateEvaluatorFactory {
 
     DictionaryBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, Dictionary dictionary, DataType dataType) {
       super(notEqPredicate, dictionary);
-      String predicateValue = PredicateUtils.getStoredValue(notEqPredicate.getValue(), dataType);
-      _nonMatchingDictId = dictionary.indexOf(predicateValue);
+      if (dataType == DataType.UUID) {
+        _nonMatchingDictId = dictionary.indexOf(new ByteArray(UuidUtils.toBytes(notEqPredicate.getValue())));
+      } else {
+        String predicateValue = PredicateUtils.getStoredValue(notEqPredicate.getValue(), dataType);
+        _nonMatchingDictId = dictionary.indexOf(predicateValue);
+      }
       if (_nonMatchingDictId >= 0) {
         _nonMatchingDictIds = new int[]{_nonMatchingDictId};
         if (dictionary.length() == 1) {
@@ -384,10 +392,17 @@ public class NotEqualsPredicateEvaluatorFactory {
 
   private static final class BytesRawValueBasedNeqPredicateEvaluator extends NeqRawPredicateEvaluator {
     final byte[] _nonMatchingValue;
+    final DataType _dataType;
 
     BytesRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, byte[] nonMatchingValue) {
+      this(notEqPredicate, nonMatchingValue, DataType.BYTES);
+    }
+
+    BytesRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, byte[] nonMatchingValue,
+        DataType dataType) {
       super(notEqPredicate);
       _nonMatchingValue = nonMatchingValue;
+      _dataType = dataType;
     }
 
     @Override
@@ -397,7 +412,7 @@ public class NotEqualsPredicateEvaluatorFactory {
 
     @Override
     public DataType getDataType() {
-      return DataType.BYTES;
+      return _dataType;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 
 
 /**
@@ -149,6 +150,14 @@ public class NotInPredicateEvaluatorFactory {
           nonMatchingValues.add(value);
         }
         return new BytesRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
+      }
+      case UUID: {
+        ByteArray[] uuidValues = notInPredicate.getUuidValues();
+        Set<UuidKey> nonMatchingValues = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(uuidValues.length));
+        for (ByteArray value : uuidValues) {
+          nonMatchingValues.add(UuidKey.fromByteArray(value));
+        }
+        return new UuidRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
       }
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
@@ -489,6 +498,40 @@ public class NotInPredicateEvaluatorFactory {
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.visitBytes(_nonMatchingValues);
+    }
+  }
+
+  private static final class UuidRawValueBasedNotInPredicateEvaluator extends NotInRawPredicateEvaluator {
+    final Set<UuidKey> _nonMatchingValues;
+
+    UuidRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, Set<UuidKey> nonMatchingValues) {
+      super(notInPredicate);
+      _nonMatchingValues = nonMatchingValues;
+    }
+
+    @Override
+    public int getNumMatchingItems() {
+      return -_nonMatchingValues.size();
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.UUID;
+    }
+
+    @Override
+    public boolean applySV(byte[] value) {
+      return !_nonMatchingValues.contains(UuidKey.fromBytes(value));
+    }
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      Set<ByteArray> nonMatchingByteArrays =
+          new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(_nonMatchingValues.size()));
+      for (UuidKey nonMatchingValue : _nonMatchingValues) {
+        nonMatchingByteArrays.add(nonMatchingValue.toByteArray());
+      }
+      return visitor.visitBytes(nonMatchingByteArrays);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
@@ -32,8 +32,10 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 public class PredicateUtils {
@@ -53,6 +55,10 @@ public class PredicateUtils {
         return getStoredBooleanValue(value);
       case TIMESTAMP:
         return getStoredTimestampValue(value);
+      case UUID:
+        // UUID values in range predicates are UUID strings (e.g. "550e8400-...").
+        // BYTES dictionaries store raw bytes and look up entries via hex-encoded strings.
+        return BytesUtils.toHexString(UuidUtils.toBytes(value));
       default:
         return value;
     }
@@ -179,6 +185,15 @@ public class PredicateUtils {
       case BYTES:
         ByteArray[] bytesValues = inPredicate.getBytesValues();
         for (ByteArray value : bytesValues) {
+          int dictId = dictionary.indexOf(value);
+          if (dictId >= 0) {
+            dictIdSet.add(dictId);
+          }
+        }
+        break;
+      case UUID:
+        ByteArray[] uuidValues = inPredicate.getUuidValues();
+        for (ByteArray value : uuidValues) {
           int dictId = dictionary.indexOf(value);
           if (dictId >= 0) {
             dictIdSet.add(dictId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -34,6 +34,7 @@ import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -113,6 +114,13 @@ public class RangePredicateEvaluatorFactory {
         return new BytesRawValueBasedRangePredicateEvaluator(rangePredicate,
             lowerUnbounded ? null : BytesUtils.toBytes(lowerBound),
             upperUnbounded ? null : BytesUtils.toBytes(upperBound), lowerInclusive, upperInclusive);
+      case UUID:
+        // UUID is stored as 16-byte BYTES. UUID dictionaries report getValueType() == BYTES, so the
+        // UnsortedDictionaryBasedRangePredicateEvaluator will dispatch on BYTES and call getBytesValue(),
+        // returning the raw 16-byte array which is directly comparable to the bounds below.
+        return new BytesRawValueBasedRangePredicateEvaluator(rangePredicate,
+            lowerUnbounded ? null : UuidUtils.toBytes(lowerBound),
+            upperUnbounded ? null : UuidUtils.toBytes(upperBound), lowerInclusive, upperInclusive);
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -57,6 +58,8 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.JSON, true, false);
   protected static final TransformResultMetadata BYTES_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.BYTES, true, false);
+  protected static final TransformResultMetadata UUID_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.UUID, true, false);
 
   protected static final TransformResultMetadata INT_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.INT, false, false);
@@ -78,6 +81,8 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.JSON, false, false);
   protected static final TransformResultMetadata BYTES_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.BYTES, false, false);
+  protected static final TransformResultMetadata UUID_MV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.UUID, false, false);
   protected static final TransformResultMetadata UNKNOWN_METADATA =
       new TransformResultMetadata(DataType.UNKNOWN, true, false);
 
@@ -403,12 +408,19 @@ public abstract class BaseTransformFunction implements TransformFunction {
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
     initStringValuesSV(length);
+    DataType resultDataType = getResultMetadata().getDataType();
+    if (resultDataType == DataType.UUID) {
+      byte[][] bytesValues = transformToBytesValuesSV(valueBlock);
+      for (int i = 0; i < length; i++) {
+        _stringValuesSV[i] = UuidUtils.toString(bytesValues[i]);
+      }
+      return _stringValuesSV;
+    }
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
       dictionary.readStringValues(dictIds, length, _stringValuesSV);
     } else {
-      DataType resultDataType = getResultMetadata().getDataType();
       switch (resultDataType.getStoredType()) {
         case INT:
           int[] intValues = transformToIntValuesSV(valueBlock);
@@ -463,6 +475,13 @@ public abstract class BaseTransformFunction implements TransformFunction {
       dictionary.readBytesValues(dictIds, length, _bytesValuesSV);
     } else {
       DataType resultDataType = getResultMetadata().getDataType();
+      if (resultDataType == DataType.UUID) {
+        // UUID transform functions must override transformToBytesValuesSV to return the raw 16-byte representation.
+        // Do NOT fall back to transformToStringValuesSV here — that method calls this one for UUID results, creating
+        // an infinite recursion that ends in StackOverflowError.
+        throw new UnsupportedOperationException(
+            "UUID transform function must override transformToBytesValuesSV: " + getClass().getName());
+      }
       switch (resultDataType.getStoredType()) {
         case BIG_DECIMAL:
           BigDecimal[] bigDecimalValues = transformToBigDecimalValuesSV(valueBlock);
@@ -775,6 +794,20 @@ public abstract class BaseTransformFunction implements TransformFunction {
   public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
     initStringValuesMV(length);
+    DataType resultDataType = getResultMetadata().getDataType();
+    if (resultDataType == DataType.UUID) {
+      byte[][][] bytesValuesMV = transformToBytesValuesMV(valueBlock);
+      for (int i = 0; i < length; i++) {
+        byte[][] bytesValues = bytesValuesMV[i];
+        int numValues = bytesValues.length;
+        String[] stringValues = new String[numValues];
+        for (int j = 0; j < numValues; j++) {
+          stringValues[j] = UuidUtils.toString(bytesValues[j]);
+        }
+        _stringValuesMV[i] = stringValues;
+      }
+      return _stringValuesMV;
+    }
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -786,7 +819,6 @@ public abstract class BaseTransformFunction implements TransformFunction {
         _stringValuesMV[i] = stringValues;
       }
     } else {
-      DataType resultDataType = getResultMetadata().getDataType();
       switch (resultDataType) {
         case INT:
           int[][] intValuesMV = transformToIntValuesMV(valueBlock);
@@ -843,6 +875,13 @@ public abstract class BaseTransformFunction implements TransformFunction {
       }
     } else {
       DataType resultDataType = getResultMetadata().getDataType();
+      if (resultDataType == DataType.UUID) {
+        // Symmetric to the SV guard in transformToBytesValuesSV: UUID transform functions must override
+        // transformToBytesValuesMV directly. The default switch below would otherwise fall through to a
+        // confusing "Cannot read MV BYTES as BYTES" error because UUID.getStoredType() == BYTES.
+        throw new UnsupportedOperationException(
+            "UUID MV transform function must override transformToBytesValuesMV: " + getClass().getName());
+      }
       switch (resultDataType.getStoredType()) {
         case BIG_DECIMAL:
           BigDecimal[][] bigDecimalValuesMV = transformToBigDecimalValuesMV(valueBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -110,15 +110,16 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     _leftTransformFunction = arguments.get(0);
     _rightTransformFunction = arguments.get(1);
     DataType leftDataType = _leftTransformFunction.getResultMetadata().getDataType();
+    DataType rightDataType = _rightTransformFunction.getResultMetadata().getDataType();
     _leftStoredType = leftDataType.getStoredType();
-    _rightStoredType = _rightTransformFunction.getResultMetadata().getDataType().getStoredType();
+    _rightStoredType = rightDataType.getStoredType();
 
     // Data type check: left and right types should be compatible.
     if (_leftStoredType == DataType.BYTES || _rightStoredType == DataType.BYTES) {
       Preconditions.checkState(_leftStoredType == _rightStoredType, String.format(
           "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform "
-              + "Function [%s] result type is [%s]]", _leftTransformFunction.getName(), _leftStoredType,
-          _rightTransformFunction.getName(), _rightStoredType));
+              + "Function [%s] result type is [%s]]", getTransformFunctionDisplayName(_leftTransformFunction),
+          _leftStoredType, getTransformFunctionDisplayName(_rightTransformFunction), _rightStoredType));
     }
 
     // Create predicate evaluator when the right side is a literal
@@ -697,8 +698,15 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private IllegalStateException illegalState() {
     throw new IllegalStateException(String.format(
         "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right "
-            + "Transform Function [%s] result type is [%s]]", _leftTransformFunction.getName(), _leftStoredType,
-        _rightTransformFunction.getName(), _rightStoredType));
+            + "Transform Function [%s] result type is [%s]]", getTransformFunctionDisplayName(_leftTransformFunction),
+        _leftStoredType, getTransformFunctionDisplayName(_rightTransformFunction), _rightStoredType));
+  }
+
+  private static String getTransformFunctionDisplayName(TransformFunction transformFunction) {
+    if (transformFunction instanceof IdentifierTransformFunction) {
+      return ((IdentifierTransformFunction) transformFunction).getColumnName();
+    }
+    return transformFunction.getName();
   }
 
   private void fillResultString(ValueBlock valueBlock, int length) {
@@ -712,8 +720,10 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillResultBytes(ValueBlock valueBlock, int length) {
     byte[][] leftBytesValues = _leftTransformFunction.transformToBytesValuesSV(valueBlock);
     byte[][] rightBytesValues = _rightTransformFunction.transformToBytesValuesSV(valueBlock);
+    // ByteArray.compare is unsigned byte-wise lexicographic; for canonical 16-byte big-endian UUIDs this is
+    // equivalent to UuidUtils.compare's unsigned 64-bit-word ordering, so a single comparator handles both.
     for (int i = 0; i < length; i++) {
-      _intValuesSV[i] = getIntResult((ByteArray.compare(leftBytesValues[i], rightBytesValues[i])));
+      _intValuesSV[i] = getIntResult(ByteArray.compare(leftBytesValues[i], rightBytesValues[i]));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -213,6 +214,13 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           BytesUtils.toBytes(literal);
         } catch (Exception e) {
           throw new IllegalArgumentException("Invalid literal: " + literal + " for BYTES");
+        }
+        break;
+      case UUID:
+        try {
+          UuidUtils.toBytes(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for UUID");
         }
         break;
       default:
@@ -802,7 +810,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     Map<Integer, byte[][]> thenStatementsIndexToValues = new HashMap<>();
     for (int i = 0; i < numThenStatements; i++) {
       if (_computeThenStatements[i]) {
-        thenStatementsIndexToValues.put(i, _thenStatements.get(i).transformToBytesValuesSV(valueBlock));
+        thenStatementsIndexToValues.put(i, getBytesValues(_thenStatements.get(i), valueBlock));
       }
     }
     for (int docId = 0; docId < numDocs; docId++) {
@@ -817,7 +825,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _bytesValuesSV[docId] = NullValuePlaceHolder.BYTES;
         }
       } else {
-        byte[][] bytesValues = _elseStatement.transformToBytesValuesSV(valueBlock);
+        byte[][] bytesValues = getBytesValues(_elseStatement, valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
           _bytesValuesSV[docId] = bytesValues[docId];
         }
@@ -831,14 +839,14 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     final RoaringBitmap bitmap = new RoaringBitmap();
     int[] selected = getSelectedArray(valueBlock, true);
     int numDocs = valueBlock.getNumDocs();
-    initStringValuesSV(numDocs);
+    initBytesValuesSV(numDocs);
     int numThenStatements = _thenStatements.size();
     BitSet unselectedDocs = new BitSet();
     unselectedDocs.set(0, numDocs);
     Map<Integer, Pair<byte[][], RoaringBitmap>> thenStatementsIndexToValues = new HashMap<>();
     for (int i = 0; i < numThenStatements; i++) {
       if (_computeThenStatements[i]) {
-        thenStatementsIndexToValues.put(i, ImmutablePair.of(_thenStatements.get(i).transformToBytesValuesSV(valueBlock),
+        thenStatementsIndexToValues.put(i, ImmutablePair.of(getBytesValues(_thenStatements.get(i), valueBlock),
             _thenStatements.get(i).getNullBitmap(valueBlock)));
       }
     }
@@ -863,7 +871,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           bitmap.add(docId);
         }
       } else {
-        byte[][] bytesValues = _elseStatement.transformToBytesValuesSV(valueBlock);
+        byte[][] bytesValues = getBytesValues(_elseStatement, valueBlock);
         RoaringBitmap nullBitmap = _elseStatement.getNullBitmap(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
           _bytesValuesSV[docId] = bytesValues[docId];
@@ -874,6 +882,22 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
       }
     }
     return _bytesValuesSV;
+  }
+
+  private byte[][] getBytesValues(TransformFunction transformFunction, ValueBlock valueBlock) {
+    if (_resultMetadata.getDataType() != DataType.UUID || !(transformFunction instanceof LiteralTransformFunction)) {
+      return transformFunction.transformToBytesValuesSV(valueBlock);
+    }
+    LiteralTransformFunction literalTransformFunction = (LiteralTransformFunction) transformFunction;
+    if (literalTransformFunction.isNull()
+        || literalTransformFunction.getResultMetadata().getDataType() != DataType.STRING) {
+      return transformFunction.transformToBytesValuesSV(valueBlock);
+    }
+    int numDocs = valueBlock.getNumDocs();
+    byte[][] bytesValues = new byte[numDocs][];
+    byte[] uuidBytes = UuidUtils.toBytes(literalTransformFunction.getStringLiteral());
+    Arrays.fill(bytesValues, uuidBytes);
+    return bytesValues;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -95,6 +97,14 @@ public class CastTransformFunction extends BaseTransformFunction {
         case "BYTES":
         case "VARBINARY":
           _resultMetadata = sourceSV ? BYTES_SV_NO_DICTIONARY_METADATA : BYTES_MV_NO_DICTIONARY_METADATA;
+          break;
+        case "UUID":
+          Preconditions.checkState(sourceSV, "Cannot cast from MV to UUID");
+          _resultMetadata = UUID_SV_NO_DICTIONARY_METADATA;
+          break;
+        case "UUID_ARRAY":
+          Preconditions.checkState(!sourceSV, "Cannot cast from SV to UUID_ARRAY");
+          _resultMetadata = UUID_MV_NO_DICTIONARY_METADATA;
           break;
         case "INT_ARRAY":
         case "INTEGER_ARRAY":
@@ -300,11 +310,89 @@ public class CastTransformFunction extends BaseTransformFunction {
           byte[][] bytesValues = transformToBytesValuesSV(valueBlock);
           ArrayCopyUtils.copy(bytesValues, _stringValuesSV, length);
           break;
+        case UUID:
+          byte[][] uuidValues = transformToBytesValuesSV(valueBlock);
+          for (int i = 0; i < length; i++) {
+            _stringValuesSV[i] = UuidUtils.toString(uuidValues[i]);
+          }
+          break;
         default:
           throw new IllegalStateException(String.format("Cannot cast from SV %s to STRING", resultDataType));
       }
     }
     return _stringValuesSV;
+  }
+
+  @Override
+  public byte[][] transformToBytesValuesSV(ValueBlock valueBlock) {
+    DataType resultDataType = _resultMetadata.getDataType();
+    if (resultDataType != DataType.UUID) {
+      if (resultDataType.getStoredType() == DataType.BYTES) {
+        return _transformFunction.transformToBytesValuesSV(valueBlock);
+      }
+      return super.transformToBytesValuesSV(valueBlock);
+    }
+
+    int length = valueBlock.getNumDocs();
+    initBytesValuesSV(length);
+    switch (_sourceDataType.getStoredType()) {
+      case STRING:
+        String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
+        for (int i = 0; i < length; i++) {
+          _bytesValuesSV[i] = UuidUtils.toBytes(stringValues[i]);
+        }
+        return _bytesValuesSV;
+      case BYTES:
+        byte[][] bytesValues = _transformFunction.transformToBytesValuesSV(valueBlock);
+        for (int i = 0; i < length; i++) {
+          _bytesValuesSV[i] = UuidUtils.toBytes(bytesValues[i]);
+        }
+        return _bytesValuesSV;
+      default:
+        throw new IllegalStateException(String.format("Cannot cast from SV %s to UUID", _sourceDataType));
+    }
+  }
+
+  @Override
+  public byte[][][] transformToBytesValuesMV(ValueBlock valueBlock) {
+    DataType resultDataType = _resultMetadata.getDataType();
+    if (resultDataType != DataType.UUID) {
+      if (resultDataType.getStoredType() == DataType.BYTES) {
+        return _transformFunction.transformToBytesValuesMV(valueBlock);
+      }
+      return super.transformToBytesValuesMV(valueBlock);
+    }
+
+    int length = valueBlock.getNumDocs();
+    initBytesValuesMV(length);
+    switch (_sourceDataType.getStoredType()) {
+      case STRING:
+        String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
+        for (int i = 0; i < length; i++) {
+          String[] stringValues = stringValuesMV[i];
+          int numValues = stringValues.length;
+          byte[][] uuidValues = new byte[numValues][];
+          for (int j = 0; j < numValues; j++) {
+            uuidValues[j] = UuidUtils.toBytes(stringValues[j]);
+          }
+          _bytesValuesMV[i] = uuidValues;
+        }
+        return _bytesValuesMV;
+      case BYTES:
+        byte[][][] bytesValuesMV = _transformFunction.transformToBytesValuesMV(valueBlock);
+        for (int i = 0; i < length; i++) {
+          byte[][] bytesValues = bytesValuesMV[i];
+          int numValues = bytesValues.length;
+          byte[][] uuidValues = new byte[numValues][];
+          for (int j = 0; j < numValues; j++) {
+            uuidValues[j] = UuidUtils.toBytes(bytesValues[j]);
+          }
+          _bytesValuesMV[i] = uuidValues;
+        }
+        return _bytesValuesMV;
+      default:
+        throw new IllegalStateException(String.format("Cannot cast from MV %s to UUID", _sourceDataType));
+    }
   }
 
   @Override
@@ -457,6 +545,18 @@ public class CastTransformFunction extends BaseTransformFunction {
         case TIMESTAMP:
           longValuesMV = transformToTimestampValuesMV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValuesMV, _stringValuesMV, length);
+          break;
+        case UUID:
+          byte[][][] uuidValuesMV = transformToBytesValuesMV(valueBlock);
+          for (int i = 0; i < length; i++) {
+            byte[][] uuidValues = uuidValuesMV[i];
+            int numValues = uuidValues.length;
+            String[] stringValues = new String[numValues];
+            for (int j = 0; j < numValues; j++) {
+              stringValues[j] = UuidUtils.toString(uuidValues[j]);
+            }
+            _stringValuesMV[i] = stringValues;
+          }
           break;
         default:
           throw new IllegalStateException(String.format("Cannot cast from MV %s to STRING", resultDataType));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -28,6 +28,8 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -39,6 +41,8 @@ public class IdentifierTransformFunction implements TransformFunction {
   private final String _columnName;
   private final Dictionary _dictionary;
   private final TransformResultMetadata _resultMetadata;
+  private String[] _uuidStringValuesSV;
+  private String[][] _uuidStringValuesMV;
 
   public IdentifierTransformFunction(String columnName, ColumnContext columnContext) {
     _columnName = columnName;
@@ -115,6 +119,19 @@ public class IdentifierTransformFunction implements TransformFunction {
 
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
+    if (_resultMetadata.getDataType() == DataType.UUID) {
+      int numDocs = valueBlock.getNumDocs();
+      String[] uuidStringValuesSV = _uuidStringValuesSV;
+      if (uuidStringValuesSV == null || uuidStringValuesSV.length < numDocs) {
+        uuidStringValuesSV = new String[numDocs];
+        _uuidStringValuesSV = uuidStringValuesSV;
+      }
+      byte[][] bytesValues = valueBlock.getBlockValueSet(_columnName).getBytesValuesSV();
+      for (int i = 0; i < numDocs; i++) {
+        uuidStringValuesSV[i] = UuidUtils.toString(bytesValues[i]);
+      }
+      return uuidStringValuesSV;
+    }
     return valueBlock.getBlockValueSet(_columnName).getStringValuesSV();
   }
 
@@ -150,6 +167,25 @@ public class IdentifierTransformFunction implements TransformFunction {
 
   @Override
   public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
+    if (_resultMetadata.getDataType() == DataType.UUID) {
+      int numDocs = valueBlock.getNumDocs();
+      String[][] uuidStringValuesMV = _uuidStringValuesMV;
+      if (uuidStringValuesMV == null || uuidStringValuesMV.length < numDocs) {
+        uuidStringValuesMV = new String[numDocs][];
+        _uuidStringValuesMV = uuidStringValuesMV;
+      }
+      byte[][][] bytesValuesMV = valueBlock.getBlockValueSet(_columnName).getBytesValuesMV();
+      for (int i = 0; i < numDocs; i++) {
+        byte[][] bytesValues = bytesValuesMV[i];
+        int numValues = bytesValues.length;
+        String[] uuidValues = new String[numValues];
+        for (int j = 0; j < numValues; j++) {
+          uuidValues[j] = UuidUtils.toString(bytesValues[j]);
+        }
+        uuidStringValuesMV[i] = uuidValues;
+      }
+      return uuidStringValuesMV;
+    }
     return valueBlock.getBlockValueSet(_columnName).getStringValuesMV();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -118,11 +119,19 @@ public class InTransformFunction extends BaseTransformFunction {
           _valueSet = stringValues;
           break;
         case BYTES:
-          ObjectOpenHashSet<ByteArray> bytesValues = new ObjectOpenHashSet<>(numValues);
-          for (String stringValue : stringValues) {
-            bytesValues.add(BytesUtils.toByteArray(stringValue));
+          if (_mainFunction.getResultMetadata().getDataType() == DataType.UUID) {
+            ObjectOpenHashSet<UuidKey> uuidValues = new ObjectOpenHashSet<>(numValues);
+            for (String stringValue : stringValues) {
+              uuidValues.add(UuidKey.fromObject(stringValue));
+            }
+            _valueSet = uuidValues;
+          } else {
+            ObjectOpenHashSet<ByteArray> bytesValues = new ObjectOpenHashSet<>(numValues);
+            for (String stringValue : stringValues) {
+              bytesValues.add(BytesUtils.toByteArray(stringValue));
+            }
+            _valueSet = bytesValues;
           }
-          _valueSet = bytesValues;
           break;
         case UNKNOWN:
           _valueSet = new ObjectOpenHashSet<>();
@@ -203,11 +212,20 @@ public class InTransformFunction extends BaseTransformFunction {
             }
             break;
           case BYTES:
-            ObjectOpenHashSet<ByteArray> inBytesValues = (ObjectOpenHashSet<ByteArray>) _valueSet;
             byte[][] bytesValues = _mainFunction.transformToBytesValuesSV(valueBlock);
-            for (int i = 0; i < length; i++) {
-              if (inBytesValues.contains(new ByteArray(bytesValues[i]))) {
-                _intValuesSV[i] = 1;
+            if (_mainFunction.getResultMetadata().getDataType() == DataType.UUID) {
+              ObjectOpenHashSet<UuidKey> inUuidValues = (ObjectOpenHashSet<UuidKey>) _valueSet;
+              for (int i = 0; i < length; i++) {
+                if (inUuidValues.contains(UuidKey.fromBytes(bytesValues[i]))) {
+                  _intValuesSV[i] = 1;
+                }
+              }
+            } else {
+              ObjectOpenHashSet<ByteArray> inBytesValues = (ObjectOpenHashSet<ByteArray>) _valueSet;
+              for (int i = 0; i < length; i++) {
+                if (inBytesValues.contains(new ByteArray(bytesValues[i]))) {
+                  _intValuesSV[i] = 1;
+                }
               }
             }
             break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionUtils;
@@ -35,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.apache.pinot.spi.utils.PinotDataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -374,6 +376,36 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     return _stringValuesMV;
   }
 
+  @Override
+  public byte[][][] transformToBytesValuesMV(ValueBlock valueBlock) {
+    if (_resultMetadata.getDataType().getStoredType() != DataType.BYTES) {
+      return super.transformToBytesValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initBytesValuesMV(length);
+    getNonLiteralValues(valueBlock);
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < _numNonLiteralArguments; j++) {
+        _scalarArguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
+      }
+      Object value = _functionInvoker.invoke(_scalarArguments);
+      if (value == null) {
+        _bytesValuesMV[i] = NullValuePlaceHolder.BYTES_ARRAY;
+        continue;
+      }
+      // BYTES_ARRAY scalars return ByteArray[] via toInternal (default returns value as-is and the convention
+      // is ByteArray[]); UUID_ARRAY scalars return byte[][] directly (PinotDataType.UUID_ARRAY#toInternal
+      // overrides to byte[][]). Handle both shapes so callers do not ClassCast.
+      Object internal = _resultType.toInternal(value);
+      if (internal instanceof byte[][]) {
+        _bytesValuesMV[i] = (byte[][]) internal;
+      } else {
+        _bytesValuesMV[i] = toBytesArray((ByteArray[]) internal);
+      }
+    }
+    return _bytesValuesMV;
+  }
+
   /**
    * Helper method to fetch values for the non-literal transform functions based on the parameter types.
    */
@@ -424,6 +456,16 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
         case BYTES:
           _nonLiteralValues[i] = transformFunction.transformToBytesValuesSV(valueBlock);
           break;
+        case UUID: {
+          byte[][] bytesValues = transformFunction.transformToBytesValuesSV(valueBlock);
+          int numValues = bytesValues.length;
+          UUID[] uuidValues = new UUID[numValues];
+          for (int j = 0; j < numValues; j++) {
+            uuidValues[j] = UuidUtils.toUUID(bytesValues[j]);
+          }
+          _nonLiteralValues[i] = uuidValues;
+          break;
+        }
         case PRIMITIVE_INT_ARRAY:
           _nonLiteralValues[i] = transformFunction.transformToIntValuesMV(valueBlock);
           break;
@@ -477,9 +519,36 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
         case BYTES_ARRAY:
           _nonLiteralValues[i] = transformFunction.transformToBytesValuesMV(valueBlock);
           break;
+        case UUID_ARRAY:
+          _nonLiteralValues[i] = toUuidValuesMV(transformFunction.transformToBytesValuesMV(valueBlock));
+          break;
         default:
           throw new IllegalStateException("Unsupported parameter type: " + parameterType);
       }
     }
+  }
+
+  private static UUID[][] toUuidValuesMV(byte[][][] bytesValuesMV) {
+    int numDocs = bytesValuesMV.length;
+    UUID[][] uuidValuesMV = new UUID[numDocs][];
+    for (int i = 0; i < numDocs; i++) {
+      byte[][] bytesValues = bytesValuesMV[i];
+      int numValues = bytesValues.length;
+      UUID[] uuidValues = new UUID[numValues];
+      for (int j = 0; j < numValues; j++) {
+        uuidValues[j] = UuidUtils.toUUID(bytesValues[j]);
+      }
+      uuidValuesMV[i] = uuidValues;
+    }
+    return uuidValuesMV;
+  }
+
+  private static byte[][] toBytesArray(ByteArray[] byteArray) {
+    int numValues = byteArray.length;
+    byte[][] bytesArray = new byte[numValues][];
+    for (int i = 0; i < numValues; i++) {
+      bytesArray[i] = byteArray[i].getBytes();
+    }
+    return bytesArray;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
@@ -236,7 +236,7 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
       public boolean mightBeContained(BloomFilterReader bloomFilter) {
         if (!_hashed) {
           GuavaBloomFilterReaderUtils.Hash128AsLongs hash128AsLongs =
-              GuavaBloomFilterReaderUtils.hashAsLongs(_comparableValue.toString());
+              GuavaBloomFilterReaderUtils.hashAsLongs(_dt.toString(_comparableValue));
           _hash1 = hash128AsLongs.getHash1();
           _hash2 = hash128AsLongs.getHash2();
           _hashed = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -80,6 +81,8 @@ public class PredicateRowMatcher implements RowMatcher {
         return _predicateEvaluator.applySV((String) value);
       case BYTES:
         return _predicateEvaluator.applySV((byte[]) value);
+      case UUID:
+        return _predicateEvaluator.applySV(UuidUtils.toBytes(value));
       default:
         throw new IllegalStateException();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.NotInPredicate;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -364,5 +365,41 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
+  }
+
+  @Test
+  public void testUuidPredicateEvaluators() {
+    List<String> uuidStrings = new ArrayList<>(NUM_PREDICATE_VALUES);
+    Set<String> uuidStringSet = new HashSet<>();
+
+    for (int i = 0; i < NUM_PREDICATE_VALUES; i++) {
+      String uuidString = java.util.UUID.randomUUID().toString();
+      uuidStrings.add(uuidString);
+      uuidStringSet.add(uuidString);
+    }
+
+    InPredicate inPredicate = new InPredicate(COLUMN_EXPRESSION, uuidStrings);
+    PredicateEvaluator inPredicateEvaluator =
+        InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.UUID);
+
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_EXPRESSION, uuidStrings);
+    PredicateEvaluator notInPredicateEvaluator =
+        NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.UUID);
+
+    Assert.assertEquals(inPredicateEvaluator.getDataType(), FieldSpec.DataType.UUID);
+    Assert.assertEquals(notInPredicateEvaluator.getDataType(), FieldSpec.DataType.UUID);
+
+    for (String uuidString : uuidStringSet) {
+      byte[] uuidBytes = UuidUtils.toBytes(uuidString);
+      Assert.assertTrue(inPredicateEvaluator.applySV(uuidBytes));
+      Assert.assertFalse(notInPredicateEvaluator.applySV(uuidBytes));
+    }
+
+    for (int i = 0; i < NUM_PREDICATE_VALUES; i++) {
+      byte[] value = UuidUtils.toBytes(java.util.UUID.randomUUID());
+      boolean expected = uuidStringSet.contains(UuidUtils.toString(value));
+      Assert.assertEquals(inPredicateEvaluator.applySV(value), expected);
+      Assert.assertEquals(notInPredicateEvaluator.applySV(value), !expected);
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -59,6 +60,7 @@ import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.AfterClass;
@@ -83,6 +85,7 @@ public abstract class BaseTransformFunctionTest {
   protected static final String JSON_STRING_SV_COLUMN = "jsonSV";
   protected static final String STRING_SV_NULL_COLUMN = "stringSVNull";
   protected static final String BYTES_SV_COLUMN = "bytesSV";
+  protected static final String UUID_SV_COLUMN = "uuidSV";
   protected static final String VECTOR_1_COLUMN = "vector1";
   protected static final String VECTOR_2_COLUMN = "vector2";
   protected static final String ZERO_VECTOR_COLUMN = "zeroVector";
@@ -132,6 +135,7 @@ public abstract class BaseTransformFunctionTest {
   protected final String[] _jsonArrayValues = new String[NUM_ROWS];
   protected final String[] _stringAlphaNumericSVValues = new String[NUM_ROWS];
   protected final byte[][] _bytesSVValues = new byte[NUM_ROWS][];
+  protected final byte[][] _uuidSVValues = new byte[NUM_ROWS][];
   protected final int[][] _intMVValues = new int[NUM_ROWS][];
   protected final long[][] _longMVValues = new long[NUM_ROWS][];
   protected final float[][] _floatMVValues = new float[NUM_ROWS][];
@@ -181,6 +185,9 @@ public abstract class BaseTransformFunctionTest {
           df.format(RANDOM.nextInt() * RANDOM.nextDouble()));
       _stringAlphaNumericSVValues[i] = RandomStringUtils.secure().nextAlphanumeric(26);
       _bytesSVValues[i] = RandomStringUtils.secure().nextAlphanumeric(26).getBytes();
+      long mostSignificantBits = (i % 2 == 0) ? Long.MIN_VALUE + i : Long.MAX_VALUE - i;
+      long leastSignificantBits = ((long) i << Integer.SIZE) | i;
+      _uuidSVValues[i] = UuidUtils.toBytes(new UUID(mostSignificantBits, leastSignificantBits));
 
       int numValues = 1 + RANDOM.nextInt(MAX_NUM_MULTI_VALUES);
       _intMVValues[i] = new int[numValues];
@@ -251,6 +258,7 @@ public abstract class BaseTransformFunctionTest {
         map.put(STRING_ALPHANUM_NULL_SV_COLUMN, _stringAlphaNumericSVValues[i]);
       }
       map.put(BYTES_SV_COLUMN, _bytesSVValues[i]);
+      map.put(UUID_SV_COLUMN, _uuidSVValues[i]);
 
       map.put(INT_MV_COLUMN, ArrayUtils.toObject(_intMVValues[i]));
       // Same values as INT_MV_COLUMN so callers can compare results against the dict-encoded baseline and
@@ -304,6 +312,7 @@ public abstract class BaseTransformFunctionTest {
         .addSingleValueDimension(STRING_ALPHANUM_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(STRING_ALPHANUM_NULL_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(BYTES_SV_COLUMN, FieldSpec.DataType.BYTES)
+        .addSingleValueDimension(UUID_SV_COLUMN, FieldSpec.DataType.UUID)
         .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
         .addSingleValueDimension(DEFAULT_JSON_COLUMN, FieldSpec.DataType.JSON)
         .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
@@ -652,8 +661,13 @@ public abstract class BaseTransformFunctionTest {
   protected void testTransformFunction(TransformFunction transformFunction, byte[][] expectedValues) {
     String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
     byte[][] bytesValues = transformFunction.transformToBytesValuesSV(_projectionBlock);
+    FieldSpec.DataType resultDataType = transformFunction.getResultMetadata().getDataType();
     for (int i = 0; i < NUM_ROWS; i++) {
-      assertEquals(bytesValues[i], BytesUtils.toBytes(stringValues[i]));
+      if (resultDataType == FieldSpec.DataType.UUID) {
+        assertEquals(bytesValues[i], UuidUtils.toBytes(stringValues[i]));
+      } else {
+        assertEquals(bytesValues[i], BytesUtils.toBytes(stringValues[i]));
+      }
       assertEquals(bytesValues[i], expectedValues[i]);
     }
     testNullBitmap(transformFunction, null);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -261,6 +262,35 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
       }
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, bitmap);
+  }
+
+  @Test
+  public void testBinaryOperatorTransformFunctionUUID() {
+    String functionName = getFunctionName();
+    String uuidLiteral = UuidUtils.toString(_uuidSVValues[0]);
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("%s(%s, CAST('%s' AS UUID))", functionName, UUID_SV_COLUMN, uuidLiteral));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    boolean[] expectedValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = getExpectedValue(UuidUtils.compare(_uuidSVValues[i], _uuidSVValues[0]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testBinaryOperatorTransformFunctionUUIDNoDict() {
+    String functionName = getFunctionName();
+    String uuidLiteral = UuidUtils.toString(_uuidSVValues[0]);
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("%s(CAST(CAST(%s AS STRING) AS UUID), CAST('%s' AS UUID))", functionName, UUID_SV_COLUMN,
+            uuidLiteral));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    boolean[] expectedValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = getExpectedValue(UuidUtils.compare(_uuidSVValues[i], _uuidSVValues[0]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -167,7 +168,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
         String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, BYTES_SV_COLUMN),
         String.format("CASE WHEN true THEN 100 ELSE %s END", TIMESTAMP_COLUMN),
         String.format("CASE WHEN true THEN 100 ELSE %s END", STRING_SV_COLUMN),
-        String.format("CASE WHEN true THEN 100 ELSE %s END", BYTES_SV_COLUMN)
+        String.format("CASE WHEN true THEN 100 ELSE %s END", BYTES_SV_COLUMN),
+        "CASE WHEN true THEN CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID) ELSE 'not-a-uuid' END"
     };
     //@formatter:on
   }
@@ -175,6 +177,42 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
   @Test(dataProvider = "illegalExpressions", expectedExceptions = Exception.class)
   public void testInvalidCaseTransformFunction(String expression) {
     TransformFunctionFactory.get(RequestContextUtils.getExpression(expression), _dataSourceMap);
+  }
+
+  @Test
+  public void testCaseTransformFunctionWithUuidResults() {
+    String uuidValue = "550e8400-e29b-41d4-a716-446655440000";
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        "CASE WHEN true THEN CAST('" + uuidValue.toUpperCase() + "' AS UUID) ELSE '" + uuidValue + "' END");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.UUID);
+    byte[][] expectedValues = new byte[NUM_ROWS][];
+    byte[] uuidBytes = UuidUtils.toBytes(uuidValue);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = uuidBytes;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testCaseTransformFunctionWithUuidStringLiteralBranch() {
+    String whenUuidValue = "550e8400-e29b-41d4-a716-446655440000";
+    String elseUuidValue = "550e8400-e29b-41d4-a716-446655440001";
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CASE WHEN %s < 2 THEN '%s' ELSE CAST('%s' AS UUID) END", INT_SV_COLUMN,
+            whenUuidValue.toUpperCase(), elseUuidValue));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.UUID);
+
+    byte[][] expectedValues = new byte[NUM_ROWS][];
+    byte[] whenUuidBytes = UuidUtils.toBytes(whenUuidValue);
+    byte[] elseUuidBytes = UuidUtils.toBytes(elseUuidValue);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intSVValues[i] < 2 ? whenUuidBytes : elseUuidBytes;
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -35,6 +37,8 @@ import static org.testng.Assert.assertTrue;
 
 
 public class CastTransformFunctionTest extends BaseTransformFunctionTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
   @Test
   public void testCastTransformFunction() {
     ExpressionContext expression =
@@ -170,6 +174,52 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
   }
 
   @Test
+  public void testCastTransformFunctionUUID() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("CAST('%s' AS UUID)", UUID_VALUE.toUpperCase()));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof CastTransformFunction);
+    assertEquals(transformFunction.getResultMetadata().getDataType(), FieldSpec.DataType.UUID);
+
+    byte[][] bytesValues = transformFunction.transformToBytesValuesSV(_projectionBlock);
+    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    byte[] expectedBytes = UuidUtils.toBytes(UUID_VALUE);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(bytesValues[i], expectedBytes);
+      Assert.assertEquals(stringValues[i], UUID_VALUE);
+    }
+  }
+
+  @Test
+  public void testCastTransformFunctionUuidRoundTrips() {
+    String bytesHex = org.apache.pinot.spi.utils.BytesUtils.toHexString(UuidUtils.toBytes(UUID_VALUE));
+
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CAST(CAST('%s' AS BYTES) AS UUID)", bytesHex));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    byte[] expectedBytes = UuidUtils.toBytes(UUID_VALUE);
+    byte[][] expectedUuidValues = new byte[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedUuidValues[i] = expectedBytes;
+    }
+    testTransformFunction(transformFunction, expectedUuidValues);
+
+    expression = RequestContextUtils.getExpression(String.format("CAST(CAST('%s' AS UUID) AS STRING)", UUID_VALUE));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    String[] expectedStringValues = new String[NUM_ROWS];
+    Arrays.fill(expectedStringValues, UUID_VALUE);
+    testTransformFunction(transformFunction, expectedStringValues);
+
+    expression = RequestContextUtils.getExpression(String.format("CAST(CAST('%s' AS UUID) AS BYTES)", UUID_VALUE));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    byte[][] expectedBytesValues = new byte[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedBytesValues[i] = expectedBytes;
+    }
+    testTransformFunction(transformFunction, expectedBytesValues);
+  }
+
+  @Test
   public void testCastTransformFunctionMV() {
     ExpressionContext expression =
         RequestContextUtils.getExpression(String.format("CAST(%s AS LONG)", STRING_LONG_MV_COLUMN));
@@ -255,6 +305,37 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
       expectedArraySums[i] = Arrays.stream(afterCast[i]).sum();
     }
     testTransformFunction(transformFunction, expectedArraySums);
+  }
+
+  @Test
+  public void testCastTransformFunctionUUIDRejectsInvalidLiteral() {
+    ExpressionContext expression = RequestContextUtils.getExpression("CAST('not-a-uuid' AS UUID)");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CastTransformFunction);
+
+    IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
+        () -> transformFunction.transformToBytesValuesSV(_projectionBlock));
+    Assert.assertTrue(exception.getMessage().contains("Invalid UUID"));
+  }
+
+  @Test
+  public void testCastTransformFunctionUUIDRejectsInvalidBytesLiteral() {
+    ExpressionContext expression = RequestContextUtils.getExpression("CAST(CAST('0011' AS BYTES) AS UUID)");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CastTransformFunction);
+
+    IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
+        () -> transformFunction.transformToBytesValuesSV(_projectionBlock));
+    Assert.assertTrue(exception.getMessage().contains("Invalid UUID byte length"));
+  }
+
+  @Test
+  public void testCastTransformFunctionUUIDRejectsMVSource() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("CAST(%s AS UUID)", STRING_MV_COLUMN));
+    BadQueryRequestException exception = Assert.expectThrows(BadQueryRequestException.class,
+        () -> TransformFunctionFactory.get(expression, _dataSourceMap));
+    Assert.assertTrue(exception.getMessage().contains("Cannot cast from MV to UUID"));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -25,21 +25,28 @@ import java.sql.Timestamp;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.scalar.ArithmeticFunctions;
 import org.apache.pinot.common.function.scalar.IpAddressFunctions;
 import org.apache.pinot.common.function.scalar.StringFunctions;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.Test;
 
@@ -1199,6 +1206,28 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   }
 
   @Test
+  public void testUuidColumnArgumentTransformFunction()
+      throws NoSuchMethodException {
+    byte[][] uuidValues = new byte[NUM_ROWS][];
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      UUID uuid = new UUID(i, i + 1L);
+      uuidValues[i] = UuidUtils.toBytes(uuid);
+      expectedValues[i] = uuid.toString();
+    }
+
+    ScalarTransformFunctionWrapper transformFunction =
+        new ScalarTransformFunctionWrapper(FunctionInfo.fromMethod(
+            ScalarTransformFunctionWrapperTest.class.getDeclaredMethod("uuidToString", UUID.class)));
+    StaticUuidTransformFunction uuidTransformFunction = new StaticUuidTransformFunction(uuidValues);
+    uuidTransformFunction.init(List.of(), Map.of());
+    transformFunction.init(Arrays.asList(uuidTransformFunction), Map.of());
+
+    assertEquals(transformFunction.getName(), "uuidToString");
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
   public void testStringLowerTransformFunctionNullLiteral() {
     ExpressionContext expression =
         RequestContextUtils.getExpression("lower(null)");
@@ -1662,5 +1691,34 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
       expectedValues[i] = sum;
     }
     testTransformFunction(transformFunction, expectedValues);
+  }
+
+  public static String uuidToString(UUID uuid) {
+    return uuid.toString();
+  }
+
+  private static class StaticUuidTransformFunction extends BaseTransformFunction {
+    private static final TransformResultMetadata RESULT_METADATA = new TransformResultMetadata(DataType.UUID, true,
+        false);
+    private final byte[][] _uuidValues;
+
+    private StaticUuidTransformFunction(byte[][] uuidValues) {
+      _uuidValues = uuidValues;
+    }
+
+    @Override
+    public String getName() {
+      return "staticUuid";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return RESULT_METADATA;
+    }
+
+    @Override
+    public byte[][] transformToBytesValuesSV(ValueBlock valueBlock) {
+      return _uuidValues;
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
@@ -95,6 +95,22 @@ public class BloomFilterSegmentPrunerTest {
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21.0 AND column = 30.0"));
   }
 
+  @Test
+  public void testUuidBloomFilterPruning()
+      throws IOException {
+    IndexSegment indexSegment = mockIndexSegment(new String[]{
+        "550e8400-e29b-41d4-a716-446655440000",
+        "550e8400-e29b-41d4-a716-446655440001"
+    }, DataType.UUID);
+
+    assertFalse(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column = '550e8400-e29b-41d4-a716-446655440000'"));
+    assertFalse(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column IN ('550e8400-e29b-41d4-a716-446655440001')"));
+    assertTrue(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column = '550e8400-e29b-41d4-a716-44665544ffff'"));
+  }
+
   @Test(expectedExceptions = RuntimeException.class)
   public void testQueryTimeoutOnPruning()
       throws IOException {
@@ -161,6 +177,11 @@ public class BloomFilterSegmentPrunerTest {
 
   private IndexSegment mockIndexSegment(String[] values)
       throws IOException {
+    return mockIndexSegment(values, DataType.DOUBLE);
+  }
+
+  private IndexSegment mockIndexSegment(String[] values, DataType dataType)
+      throws IOException {
     IndexSegment indexSegment = mock(IndexSegment.class);
     when(indexSegment.getColumnNames()).thenReturn(ImmutableSet.of("column"));
     SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
@@ -175,7 +196,7 @@ public class BloomFilterSegmentPrunerTest {
     for (String v : values) {
       builder.put(v);
     }
-    when(dataSourceMetadata.getDataType()).thenReturn(DataType.DOUBLE);
+    when(dataSourceMetadata.getDataType()).thenReturn(dataType);
     when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
     when(dataSource.getBloomFilter()).thenReturn(builder.build());
 


### PR DESCRIPTION
## What
Single-stage engine query semantics for UUID.

## Changes
- `RequestContextUtils` literal folding (`CAST(... AS UUID)`, `toUuid`, conversions)
- predicate evaluators: equality / not-equals / IN / NOT IN / range (raw-value)
- transform functions: CAST, IN, CASE, binary-op, identifier, scalar-wrapper
- `LiteralContext`, `BaseInPredicate`, `FunctionUtils`, `PredicateComparisonRewriter`

## Enables
`WHERE uuidCol = CAST('...' AS UUID)`, `IN (...)`, range and equality filtering.

## Depends on
PR 1.

## Why this PR exists
This is **part 4 of 8** splitting [apache/pinot#18140](https://github.com/apache/pinot/pull/18140) (first-class logical `UUID` type) into reviewable, layered PRs, as requested on that PR.

The split is enabled by the v1 design: `DataType.UUID` has **stored type `BYTES`**, so most code paths handle it automatically; each PR adds explicit UUID semantics to one subsystem.

This PR is **stacked on `03-result-rendering`** (its base branch), so the diff shown here is **only this layer**.

### Full stack (base → top)
1. `uuid-split/01-spi-foundation` — Add logical UUID type foundation (pinot-spi)
2. `uuid-split/02-ingest-storage` — UUID ingest and segment storage
3. `uuid-split/03-result-rendering` — UUID result rendering (DataSchema, Arrow/JSON encoders)
4. `uuid-split/04-sse-predicates-cast` — UUID server-side predicates, CAST and transforms
5. `uuid-split/05-agg-groupby-distinct` — UUID aggregation, group-by and distinct
6. `uuid-split/06-mse-planner-runtime` — UUID multi-stage engine (planner + runtime)
7. `uuid-split/07-udfs-partitioning` — UUID scalar UDFs and partitioning
8. `uuid-split/08-it-bench-docs` — UUID integration tests, benchmarks and docs

Full feature description, v1 design contract, scope exclusions, and benchmark numbers: [apache/pinot#18140](https://github.com/apache/pinot/pull/18140).
