### PR TITLE
[UUID 5/8] UUID aggregation, group-by and distinct

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -55,6 +55,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -140,22 +141,22 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
           break;
         case DISTINCTCOUNTHLL:
         case DISTINCTCOUNTHLLMV:
-          result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountHLLResult(dataSource,
               (DistinctCountHLLAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTRAWHLL:
         case DISTINCTCOUNTRAWHLLMV:
-          result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountHLLResult(dataSource,
               ((DistinctCountRawHLLAggregationFunction) aggregationFunction).getDistinctCountHLLAggregationFunction());
           break;
         case DISTINCTCOUNTHLLPLUS:
         case DISTINCTCOUNTHLLPLUSMV:
-          result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountHLLPlusResult(dataSource,
               (DistinctCountHLLPlusAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTRAWHLLPLUS:
         case DISTINCTCOUNTRAWHLLPLUSMV:
-          result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountHLLPlusResult(dataSource,
               ((DistinctCountRawHLLPlusAggregationFunction) aggregationFunction)
                   .getDistinctCountHLLPlusAggregationFunction());
           break;
@@ -171,7 +172,7 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
               (DistinctCountSmartHLLPlusAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTULL:
-          result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountULLResult(dataSource,
               (DistinctCountULLAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTSMARTULL:
@@ -179,7 +180,7 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
               (DistinctCountSmartULLAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTRAWULL:
-          result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountULLResult(dataSource,
               (DistinctCountULLAggregationFunction) aggregationFunction);
           break;
         default:
@@ -331,8 +332,20 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     return hllPlus;
   }
 
-  private static HyperLogLog getDistinctCountHLLResult(Dictionary dictionary,
+  private static HyperLogLog getDistinctCountHLLResult(DataSource dataSource,
       DistinctCountHLLAggregationFunction function) {
+    Dictionary dictionary = Objects.requireNonNull(dataSource.getDictionary());
+    // UUID dictionary entries are 16-byte logical scalars, not serialized HyperLogLogs. Offer canonical UUID
+    // strings so the result matches the scan-based path and DISTINCTCOUNTHLL(CAST(uuidCol AS STRING)).
+    if (dataSource.getDataSourceMetadata().getDataType() == DataType.UUID) {
+      HyperLogLog hll = new HyperLogLog(function.getLog2m());
+      int length = dictionary.length();
+      for (int i = 0; i < length; i++) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
+        hll.offer(UuidUtils.toString(dictionary.getBytesValue(i)));
+      }
+      return hll;
+    }
     if (dictionary.getValueType() == DataType.BYTES) {
       // Treat BYTES value as serialized HyperLogLog
       try {
@@ -352,8 +365,20 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
   }
 
-  private static HyperLogLogPlus getDistinctCountHLLPlusResult(Dictionary dictionary,
+  private static HyperLogLogPlus getDistinctCountHLLPlusResult(DataSource dataSource,
       DistinctCountHLLPlusAggregationFunction function) {
+    Dictionary dictionary = Objects.requireNonNull(dataSource.getDictionary());
+    // UUID dictionary entries are 16-byte logical scalars, not serialized HyperLogLogPluses. Offer canonical UUID
+    // strings so the result matches the scan-based path and DISTINCTCOUNTHLLPLUS(CAST(uuidCol AS STRING)).
+    if (dataSource.getDataSourceMetadata().getDataType() == DataType.UUID) {
+      HyperLogLogPlus hllPlus = new HyperLogLogPlus(function.getP(), function.getSp());
+      int length = dictionary.length();
+      for (int i = 0; i < length; i++) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
+        hllPlus.offer(UuidUtils.toString(dictionary.getBytesValue(i)));
+      }
+      return hllPlus;
+    }
     if (dictionary.getValueType() == DataType.BYTES) {
       // Treat BYTES value as serialized HyperLogLogPlus
       try {
@@ -393,8 +418,20 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
   }
 
-  private static UltraLogLog getDistinctCountULLResult(Dictionary dictionary,
+  private static UltraLogLog getDistinctCountULLResult(DataSource dataSource,
       DistinctCountULLAggregationFunction function) {
+    Dictionary dictionary = Objects.requireNonNull(dataSource.getDictionary());
+    // UUID dictionary entries are 16-byte logical scalars, not serialized UltraLogLogs. Hash canonical UUID
+    // strings so the result matches the scan-based path and DISTINCTCOUNTULL(CAST(uuidCol AS STRING)).
+    if (dataSource.getDataSourceMetadata().getDataType() == DataType.UUID) {
+      UltraLogLog ull = UltraLogLog.create(function.getP());
+      int length = dictionary.length();
+      for (int i = 0; i < length; i++) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
+        UltraLogLogUtils.hashObject(UuidUtils.toString(dictionary.getBytesValue(i))).ifPresent(ull::add);
+      }
+      return ull;
+    }
     if (dictionary.getValueType() == DataType.BYTES) {
       // Treat BYTES value as serialized UltraLogLog and merge
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
@@ -341,6 +341,13 @@ public class AnyValueAggregationFunction extends NullableSingleInputAggregationF
     if (_resultType != null) {
       return;
     }
+    // Inspect the logical type first so a UUID column reports ColumnDataType.UUID (and the broker renders canonical
+    // RFC-4122 strings) rather than collapsing to BYTES (which would render hex). All other dispatch keys off the
+    // stored type, matching the BYTES/STRING storage convention.
+    if (bvs.getValueType() == FieldSpec.DataType.UUID) {
+      _resultType = ColumnDataType.UUID;
+      return;
+    }
     switch (bvs.getValueType().getStoredType()) {
       case INT:
         _resultType = ColumnDataType.INT;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -73,8 +74,22 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID values are logical scalars (stored as 16-byte BYTES) — not serialized RoaringBitmap state. Add the
+    // hashCode of the canonical UUID string so DISTINCTCOUNTBITMAP(uuidCol) matches
+    // DISTINCTCOUNTBITMAP(CAST(uuidCol AS STRING)).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      RoaringBitmap bitmap = getValueBitmap(aggregationResultHolder);
+      for (int i = 0; i < length; i++) {
+        bitmap.add(UuidUtils.toString(uuidBytesValues[i]).hashCode());
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized RoaringBitmap
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       RoaringBitmap valueBitmap = aggregationResultHolder.getResult();
@@ -211,8 +226,20 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: add hashCode of canonical UUID string (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        getValueBitmap(groupByResultHolder, groupKeyArray[i])
+            .add(UuidUtils.toString(uuidBytesValues[i]).hashCode());
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized RoaringBitmap
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       for (int i = 0; i < length; i++) {
@@ -352,8 +379,22 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: add hashCode of canonical UUID string (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        int hash = UuidUtils.toString(uuidBytesValues[i]).hashCode();
+        for (int groupKey : groupKeysArray[i]) {
+          getValueBitmap(groupByResultHolder, groupKey).add(hash);
+        }
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized RoaringBitmap
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -41,6 +41,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -138,8 +139,24 @@ public class DistinctCountCPCSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    FieldSpec.DataType dataType = blockValSet.getValueType();
+    FieldSpec.DataType storedType = dataType.getStoredType();
+
+    // UUID values are logical scalars (stored as 16-byte BYTES) — not serialized CPC Sketch state. Update
+    // the sketch with the canonical UUID string so DISTINCTCOUNTCPC(uuidCol) matches
+    // DISTINCTCOUNTCPC(CAST(uuidCol AS STRING)).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      // Leave the updated CpcSketch in the holder; extractAggregationResult converts it to an accumulator.
+      // Calling getAccumulator here would read the holder slot already occupied by the sketch and fail.
+      CpcSketch cpcSketch = getCpcSketch(aggregationResultHolder);
+      for (int i = 0; i < length; i++) {
+        cpcSketch.update(UuidUtils.toString(uuidBytesValues[i]));
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized CPC Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -200,8 +217,9 @@ public class DistinctCountCPCSketchAggregationFunction
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
     }
-    CpcSketchAccumulator cpcSketchAccumulator = getAccumulator(aggregationResultHolder);
-    cpcSketchAccumulator.apply(cpcSketch);
+    // The updated CpcSketch already lives in the holder (getCpcSketch stored it); extractAggregationResult
+    // converts it to a CpcSketchAccumulator. Reading the holder as an accumulator here would
+    // ClassCastException — the holder slot contains the sketch, not an accumulator.
   }
 
   @Override
@@ -209,8 +227,19 @@ public class DistinctCountCPCSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: update with canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(UuidUtils.toString(uuidBytesValues[i]));
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized CPC Sketch
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == FieldSpec.DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -280,9 +309,21 @@ public class DistinctCountCPCSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized CPC Sketch
-    DataType storedType = blockValSet.getValueType().getStoredType();
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
     boolean singleValue = blockValSet.isSingleValue();
+
+    // UUID columns: update with canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID && singleValue) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        String canonical = UuidUtils.toString(uuidBytesValues[i]);
+        for (int groupKey : groupKeysArray[i]) {
+          getCpcSketch(groupByResultHolder, groupKey).update(canonical);
+        }
+      }
+      return;
+    }
 
     if (singleValue && storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -81,8 +82,24 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns are stored as 16-byte BYTES, but a UUID value is a logical scalar — not a serialized
+    // HyperLogLog. Offer the canonical UUID string so the result matches DISTINCTCOUNTHLL on a STRING column
+    // holding the same logical UUIDs. NOTE: fetch raw bytes and convert explicitly — for identifier expressions
+    // the BlockValSet is a ProjectionBlockValSet whose getStringValuesSV() renders stored BYTES as bare hex,
+    // not the canonical RFC-4122 form.
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+      for (int i = 0; i < length; i++) {
+        hyperLogLog.offer(UuidUtils.toString(uuidBytesValues[i]));
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized HyperLogLog
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -232,8 +249,19 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: offer canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(UuidUtils.toString(uuidBytesValues[i]));
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized HyperLogLog
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -381,8 +409,22 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: offer canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        String canonical = UuidUtils.toString(uuidBytesValues[i]);
+        for (int groupKey : groupKeysArray[i]) {
+          getHyperLogLog(groupByResultHolder, groupKey).offer(canonical);
+        }
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized HyperLogLog
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
@@ -37,6 +37,7 @@ import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -93,8 +94,21 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID values are logical scalars (stored as 16-byte BYTES) — not serialized HyperLogLogPlus state. Offer the
+    // canonical UUID string so DISTINCTCOUNTHLLPLUS(uuidCol) matches DISTINCTCOUNTHLLPLUS(CAST(uuidCol AS STRING)).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+      for (int i = 0; i < length; i++) {
+        hyperLogLogPlus.offer(UuidUtils.toString(uuidBytesValues[i]));
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized HyperLogLogPlus
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -237,8 +251,19 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: offer canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(UuidUtils.toString(uuidBytesValues[i]));
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized HyperLogLogPlus
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -385,8 +410,22 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: offer canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        String canonical = UuidUtils.toString(uuidBytesValues[i]);
+        for (int groupKey : groupKeysArray[i]) {
+          getHyperLogLogPlus(groupByResultHolder, groupKey).offer(canonical);
+        }
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized HyperLogLogPlus
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -56,6 +56,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 
 
@@ -195,7 +196,7 @@ public class DistinctCountThetaSketchAggregationFunction
     boolean[] singleValues = new boolean[numExpressions];
     DataType[] valueTypes = new DataType[numExpressions];
     Object[] valueArrays = new Object[numExpressions];
-    extractValues(blockValSetMap, singleValues, valueTypes, valueArrays);
+    extractValues(length, blockValSetMap, singleValues, valueTypes, valueArrays);
     int numFilters = _filterEvaluators.size();
 
     // Main expression is always index 0
@@ -444,7 +445,7 @@ public class DistinctCountThetaSketchAggregationFunction
     boolean[] singleValues = new boolean[numExpressions];
     DataType[] valueTypes = new DataType[numExpressions];
     Object[] valueArrays = new Object[numExpressions];
-    extractValues(blockValSetMap, singleValues, valueTypes, valueArrays);
+    extractValues(length, blockValSetMap, singleValues, valueTypes, valueArrays);
     int numFilters = _filterEvaluators.size();
 
     // Main expression is always index 0
@@ -668,7 +669,7 @@ public class DistinctCountThetaSketchAggregationFunction
     boolean[] singleValues = new boolean[numExpressions];
     DataType[] valueTypes = new DataType[numExpressions];
     Object[] valueArrays = new Object[numExpressions];
-    extractValues(blockValSetMap, singleValues, valueTypes, valueArrays);
+    extractValues(length, blockValSetMap, singleValues, valueTypes, valueArrays);
     int numFilters = _filterEvaluators.size();
 
     // Main expression is always index 0
@@ -1243,14 +1244,45 @@ public class DistinctCountThetaSketchAggregationFunction
   /**
    * Extracts values from the BlockValSet map.
    */
-  private void extractValues(Map<ExpressionContext, BlockValSet> blockValSetMap, boolean[] singleValues,
+  private void extractValues(int length, Map<ExpressionContext, BlockValSet> blockValSetMap, boolean[] singleValues,
       DataType[] valueTypes, Object[] valueArrays) {
     int numExpressions = _inputExpressions.size();
     for (int i = 0; i < numExpressions; i++) {
       BlockValSet blockValSet = blockValSetMap.get(_inputExpressions.get(i));
       boolean singleValue = blockValSet.isSingleValue();
-      DataType storedType = blockValSet.getValueType().getStoredType();
+      DataType dataType = blockValSet.getValueType();
+      DataType storedType = dataType.getStoredType();
       singleValues[i] = singleValue;
+      // UUID columns are stored as 16-byte BYTES but a UUID value is a logical scalar, not a pre-serialized
+      // theta sketch. Surface UUID as STRING (canonical UUID form) so the downstream update-sketch path
+      // matches DISTINCTCOUNTTHETASKETCH(CAST(uuidCol AS STRING)). Without this branch, the function would
+      // take the serialized-sketch path below and Sketch.wrap would fail on raw 16-byte UUID content.
+      // NOTE: fetch raw bytes and convert explicitly — for identifier expressions the BlockValSet is a
+      // ProjectionBlockValSet whose getStringValuesSV() renders stored BYTES as bare hex, not canonical form.
+      if (dataType == DataType.UUID) {
+        valueTypes[i] = DataType.STRING;
+        if (singleValue) {
+          byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+          String[] canonicalValues = new String[length];
+          for (int j = 0; j < length; j++) {
+            canonicalValues[j] = UuidUtils.toString(uuidBytesValues[j]);
+          }
+          valueArrays[i] = canonicalValues;
+        } else {
+          byte[][][] uuidBytesValuesMV = blockValSet.getBytesValuesMV();
+          String[][] canonicalValuesMV = new String[length][];
+          for (int j = 0; j < length; j++) {
+            byte[][] row = uuidBytesValuesMV[j];
+            String[] canonicalRow = new String[row.length];
+            for (int k = 0; k < row.length; k++) {
+              canonicalRow[k] = UuidUtils.toString(row[k]);
+            }
+            canonicalValuesMV[j] = canonicalRow;
+          }
+          valueArrays[i] = canonicalValuesMV;
+        }
+        continue;
+      }
       valueTypes[i] = storedType;
       if (singleValue) {
         switch (storedType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -82,8 +83,21 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized HyperLogLogPlus
-    DataType storedType = blockValSet.getValueType().getStoredType();
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID values are logical scalars (stored as 16-byte BYTES) — not serialized UltraLogLog state. Hash the
+    // canonical UUID string so DISTINCTCOUNTULL(uuidCol) matches DISTINCTCOUNTULL(CAST(uuidCol AS STRING)).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      UltraLogLog ull = getULL(aggregationResultHolder);
+      for (int i = 0; i < length; i++) {
+        UltraLogLogUtils.hashObject(UuidUtils.toString(uuidBytesValues[i])).ifPresent(ull::add);
+      }
+      return;
+    }
+
+    // Treat BYTES value as serialized UltraLogLog
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -155,8 +169,20 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: hash canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+        UltraLogLogUtils.hashObject(UuidUtils.toString(uuidBytesValues[i])).ifPresent(ull::add);
+      }
+      return;
+    }
+
     // Treat BYTES value as serialized UltraLogLogs
-    DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -234,8 +260,23 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized HyperLogLogPlus
-    DataType storedType = blockValSet.getValueType().getStoredType();
+    DataType dataType = blockValSet.getValueType();
+    DataType storedType = dataType.getStoredType();
+
+    // UUID columns: hash canonical UUID strings converted from raw bytes (see aggregate() for rationale).
+    if (dataType == DataType.UUID) {
+      byte[][] uuidBytesValues = blockValSet.getBytesValuesSV();
+      for (int i = 0; i < length; i++) {
+        String canonical = UuidUtils.toString(uuidBytesValues[i]);
+        for (int groupKey : groupKeysArray[i]) {
+          UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+          UltraLogLogUtils.hashObject(canonical).ifPresent(ull::add);
+        }
+      }
+      return;
+    }
+
+    // Treat BYTES value as serialized UltraLogLogs
     if (storedType == DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -159,8 +159,15 @@ public class IntegerTupleSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
+    FieldSpec.DataType dataType = blockValSet.getValueType();
+    FieldSpec.DataType storedType = dataType.getStoredType();
+    // UUID columns are stored as BYTES but contain raw 16-byte UUID values, not serialized tuple sketches.
+    // Surface a clear error rather than letting the deserialize step fail with a confusing sketch-format message.
+    if (dataType == FieldSpec.DataType.UUID) {
+      throw new IllegalStateException(getType() + " does not accept raw UUID values; pre-serialize the column as "
+          + "Integer Tuple Sketches first");
+    }
     // Treat BYTES value as serialized Integer Tuple Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
     if (storedType == FieldSpec.DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
@@ -183,8 +190,12 @@ public class IntegerTupleSketchAggregationFunction
 
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized Integer Tuple Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
+    FieldSpec.DataType dataType = blockValSet.getValueType();
+    FieldSpec.DataType storedType = dataType.getStoredType();
+    if (dataType == FieldSpec.DataType.UUID) {
+      throw new IllegalStateException(getType() + " does not accept raw UUID values; pre-serialize the column as "
+          + "Integer Tuple Sketches first");
+    }
 
     if (storedType == FieldSpec.DataType.BYTES) {
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
@@ -209,8 +220,12 @@ public class IntegerTupleSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized Integer Tuple Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
+    FieldSpec.DataType dataType = blockValSet.getValueType();
+    FieldSpec.DataType storedType = dataType.getStoredType();
+    if (dataType == FieldSpec.DataType.UUID) {
+      throw new IllegalStateException(getType() + " does not accept raw UUID values; pre-serialize the column as "
+          + "Integer Tuple Sketches first");
+    }
     boolean singleValue = blockValSet.isSingleValue();
 
     if (singleValue && storedType == FieldSpec.DataType.BYTES) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.FixedIntArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -53,7 +54,13 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
 
   private final ExpressionContext[] _groupByExpressions;
   private final int _numGroupByExpressions;
-  private final DataType[] _storedTypes;
+  /**
+   * Per-column group-key dispatch type: stored type of each column, except UUID is preserved as
+   * {@link DataType#UUID} so the on-the-fly dictionary keys on {@link org.apache.pinot.spi.utils.UuidUtils.UuidKey}
+   * instead of {@link org.apache.pinot.spi.utils.ByteArray}. For every other logical type this equals
+   * {@code logicalType.getStoredType()}.
+   */
+  private final DataType[] _dataTypes;
   private final Dictionary[] _dictionaries;
   private final ValueToIdMap[] _onTheFlyDictionaries;
   private final Object2IntOpenHashMap<FixedIntArray> _groupKeyMap;
@@ -67,7 +74,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       Map<ExpressionContext, Integer> groupByExpressionSizesFromPredicates) {
     _groupByExpressions = groupByExpressions;
     _numGroupByExpressions = groupByExpressions.length;
-    _storedTypes = new DataType[_numGroupByExpressions];
+    _dataTypes = new DataType[_numGroupByExpressions];
     _dictionaries = new Dictionary[_numGroupByExpressions];
     _onTheFlyDictionaries = new ValueToIdMap[_numGroupByExpressions];
     _isSingleValueExpressions = new boolean[_numGroupByExpressions];
@@ -77,7 +84,9 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
     for (int i = 0; i < _numGroupByExpressions; i++) {
       ExpressionContext groupByExpression = groupByExpressions[i];
       ColumnContext columnContext = projectOperator.getResultColumnContext(groupByExpression);
-      _storedTypes[i] = columnContext.getDataType().getStoredType();
+      DataType logicalType = columnContext.getDataType();
+      // Normalize to stored type, but preserve UUID so it uses UuidKey instead of ByteArray.
+      _dataTypes[i] = logicalType == DataType.UUID ? DataType.UUID : logicalType.getStoredType();
       // Take the dict-id path only when the forward index is dict-encoded. A column with EncodingType.RAW +
       // dictionaryIndex exposes a Dictionary but BlockValSet#getDictionaryIdsSV throws on its RAW forward
       // index — fall back to an on-the-fly dictionary on raw values for that case.
@@ -86,7 +95,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       if (dictionary != null) {
         _dictionaries[i] = dictionary;
       } else {
-        _onTheFlyDictionaries[i] = ValueToIdMapFactory.get(_storedTypes[i]);
+        _onTheFlyDictionaries[i] = ValueToIdMapFactory.get(_dataTypes[i]);
       }
       if (canOptimizeGroupByUpperBound) {
         Integer size = groupByExpressionSizesFromPredicates.get(groupByExpression);
@@ -123,7 +132,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       if (_dictionaries[i] != null) {
         values[i] = blockValSet.getDictionaryIdsSV();
       } else {
-        switch (_storedTypes[i]) {
+        switch (_dataTypes[i]) {
           case INT:
             values[i] = blockValSet.getIntValuesSV();
             break;
@@ -142,11 +151,12 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
           case STRING:
             values[i] = blockValSet.getStringValuesSV();
             break;
+          case UUID:
           case BYTES:
             values[i] = blockValSet.getBytesValuesSV();
             break;
           default:
-            throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedTypes[i]);
+            throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataTypes[i]);
         }
       }
     }
@@ -178,7 +188,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               } else if (columnValues instanceof double[]) {
                 keyValue = onTheFlyDictionary.put(((double[]) columnValues)[row]);
               } else if (columnValues instanceof byte[][]) {
-                keyValue = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
+                keyValue = putBytesValue(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
               } else {
                 keyValue = onTheFlyDictionary.put(((Object[]) columnValues)[row]);
               }
@@ -202,7 +212,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               } else if (columnValues instanceof double[]) {
                 keyValue = onTheFlyDictionary.getId(((double[]) columnValues)[row]);
               } else if (columnValues instanceof byte[][]) {
-                keyValue = onTheFlyDictionary.getId(new ByteArray(((byte[][]) columnValues)[row]));
+                keyValue = getBytesValueId(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
               } else {
                 keyValue = onTheFlyDictionary.getId(((Object[]) columnValues)[row]);
               }
@@ -244,7 +254,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
             } else if (columnValues instanceof double[]) {
               keyValue = onTheFlyDictionary.put(((double[]) columnValues)[row]);
             } else if (columnValues instanceof byte[][]) {
-              keyValue = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
+              keyValue = putBytesValue(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
             } else {
               keyValue = onTheFlyDictionary.put(((Object[]) columnValues)[row]);
             }
@@ -265,7 +275,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
             } else if (columnValues instanceof double[]) {
               keyValue = onTheFlyDictionary.getId(((double[]) columnValues)[row]);
             } else if (columnValues instanceof byte[][]) {
-              keyValue = onTheFlyDictionary.getId(new ByteArray(((byte[][]) columnValues)[row]));
+              keyValue = getBytesValueId(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
             } else {
               keyValue = onTheFlyDictionary.getId(((Object[]) columnValues)[row]);
             }
@@ -312,7 +322,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       } else {
         ValueToIdMap onTheFlyDictionary = _onTheFlyDictionaries[i];
         if (_isSingleValueExpressions[i]) {
-          switch (_storedTypes[i]) {
+          switch (_dataTypes[i]) {
             case INT:
               int[] intValues = blockValSet.getIntValuesSV();
               for (int j = 0; j < numDocs; j++) {
@@ -343,6 +353,12 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
                 keys[j][i] = new int[]{onTheFlyDictionary.put(stringValues[j])};
               }
               break;
+            case UUID:
+              byte[][] uuidValues = blockValSet.getBytesValuesSV();
+              for (int j = 0; j < numDocs; j++) {
+                keys[j][i] = new int[]{onTheFlyDictionary.put(UuidKey.fromBytes(uuidValues[j]))};
+              }
+              break;
             case BYTES:
               byte[][] bytesValues = blockValSet.getBytesValuesSV();
               for (int j = 0; j < numDocs; j++) {
@@ -351,10 +367,10 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               break;
             default:
               throw new IllegalArgumentException(
-                  "Illegal data type for no-dictionary key generator: " + _storedTypes[i]);
+                  "Illegal data type for no-dictionary key generator: " + _dataTypes[i]);
           }
         } else {
-          switch (_storedTypes[i]) {
+          switch (_dataTypes[i]) {
             case INT:
               int[][] intValues = blockValSet.getIntValuesMV();
               for (int j = 0; j < numDocs; j++) {
@@ -410,9 +426,20 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
                 keys[j][i] = mvKeys;
               }
               break;
+            case UUID:
+              byte[][][] uuidValues = blockValSet.getBytesValuesMV();
+              for (int j = 0; j < numDocs; j++) {
+                int mvSize = uuidValues[j].length;
+                int[] mvKeys = new int[mvSize];
+                for (int k = 0; k < mvSize; k++) {
+                  mvKeys[k] = onTheFlyDictionary.put(UuidKey.fromBytes(uuidValues[j][k]));
+                }
+                keys[j][i] = mvKeys;
+              }
+              break;
             default:
               throw new IllegalArgumentException(
-                  "Illegal data type for no-dictionary key generator: " + _storedTypes[i]);
+                  "Illegal data type for no-dictionary key generator: " + _dataTypes[i]);
           }
         }
       }
@@ -523,5 +550,20 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       }
     }
     return keys;
+  }
+
+  private static int putBytesValue(ValueToIdMap onTheFlyDictionary, byte[][] columnValues, int row, DataType dataType) {
+    if (dataType == DataType.UUID) {
+      return onTheFlyDictionary.put(UuidKey.fromBytes(columnValues[row]));
+    }
+    return onTheFlyDictionary.put(new ByteArray(columnValues[row]));
+  }
+
+  private static int getBytesValueId(ValueToIdMap onTheFlyDictionary, byte[][] columnValues, int row,
+      DataType dataType) {
+    if (dataType == DataType.UUID) {
+      return onTheFlyDictionary.getId(UuidKey.fromBytes(columnValues[row]));
+    }
+    return onTheFlyDictionary.getId(new ByteArray(columnValues[row]));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -52,7 +53,13 @@ import org.roaringbitmap.RoaringBitmap;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenerator {
   private final ExpressionContext _groupByExpression;
-  private final DataType _storedType;
+  /**
+   * Group-key dispatch type: stored type of the column, except UUID is preserved as {@link DataType#UUID} so the
+   * group-key map keys on {@link org.apache.pinot.spi.utils.UuidUtils.UuidKey} (two primitive longs) instead of
+   * {@link org.apache.pinot.spi.utils.ByteArray}. For every other logical type this equals
+   * {@code logicalType.getStoredType()}.
+   */
+  private final DataType _dataType;
   private final Map _groupKeyMap;
   private final int _globalGroupIdUpperBound;
   // TODO(nhejazi): Most of the logic between _nullHandlingEnabled=true/false is not sharable, so consider making a
@@ -69,8 +76,10 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
       @Nullable Map<ExpressionContext, Integer> groupByExpressionSizesFromPredicates) {
     _groupByExpression = groupByExpression;
     ColumnContext columnContext = projectOperator.getResultColumnContext(groupByExpression);
-    _storedType = columnContext.getDataType().getStoredType();
-    _groupKeyMap = createGroupKeyMap(_storedType);
+    DataType logicalType = columnContext.getDataType();
+    // Normalize to stored type, but preserve UUID so it uses UuidKey instead of ByteArray
+    _dataType = logicalType == DataType.UUID ? DataType.UUID : logicalType.getStoredType();
+    _groupKeyMap = createGroupKeyMap(_dataType);
     if (groupByExpressionSizesFromPredicates != null) {
       Integer size = groupByExpressionSizesFromPredicates.get(groupByExpression);
       _globalGroupIdUpperBound = size != null ? Math.min(size, numGroupsLimit) : numGroupsLimit;
@@ -98,7 +107,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     }
     int numDocs = valueBlock.getNumDocs();
 
-    switch (_storedType) {
+    switch (_dataType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < numDocs; i++) {
@@ -135,6 +144,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           groupKeys[i] = getKeyForValue(stringValues[i]);
         }
         break;
+      case UUID:
+        byte[][] uuidValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < numDocs; i++) {
+          groupKeys[i] = getKeyForValue(UuidKey.fromBytes(uuidValues[i]));
+        }
+        break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
         for (int i = 0; i < numDocs; i++) {
@@ -142,7 +157,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         }
         break;
       default:
-        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
     }
   }
 
@@ -152,7 +167,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     BlockValSet blockValSet = valueBlock.getBlockValueSet(_groupByExpression);
     int numDocs = valueBlock.getNumDocs();
 
-    switch (_storedType) {
+    switch (_dataType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
         if (nullBitmap.getCardinality() < numDocs) {
@@ -213,6 +228,16 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           Arrays.fill(groupKeys, 0, numDocs, getKeyForValue((String) null));
         }
         break;
+      case UUID:
+        byte[][] uuidValues = blockValSet.getBytesValuesSV();
+        if (nullBitmap.getCardinality() < numDocs) {
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = getKeyForValue(nullBitmap.contains(i) ? null : UuidKey.fromBytes(uuidValues[i]));
+          }
+        } else if (numDocs > 0) {
+          Arrays.fill(groupKeys, 0, numDocs, getKeyForValue((UuidKey) null));
+        }
+        break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
         if (nullBitmap.getCardinality() < numDocs) {
@@ -224,7 +249,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         }
         break;
       default:
-        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
     }
   }
 
@@ -261,6 +286,10 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         Object2IntOpenHashMap<String> stringMap = new Object2IntOpenHashMap<>();
         stringMap.defaultReturnValue(INVALID_ID);
         return stringMap;
+      case UUID:
+        Object2IntOpenHashMap<UuidKey> uuidMap = new Object2IntOpenHashMap<>();
+        uuidMap.defaultReturnValue(INVALID_ID);
+        return uuidMap;
       case BYTES:
         Object2IntOpenHashMap<ByteArray> bytesMap = new Object2IntOpenHashMap<>();
         bytesMap.defaultReturnValue(INVALID_ID);
@@ -276,7 +305,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     BlockValSet blockValSet = valueBlock.getBlockValueSet(_groupByExpression);
 
     if (_isSingleValueExpression) {
-      switch (_storedType) {
+      switch (_dataType) {
         case INT:
           int[] intValues = blockValSet.getIntValuesSV();
           for (int i = 0; i < numDocs; i++) {
@@ -307,6 +336,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
             groupKeys[i] = new int[]{getKeyForValue(stringValues[i])};
           }
           break;
+        case UUID:
+          byte[][] uuidValues = blockValSet.getBytesValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(UuidKey.fromBytes(uuidValues[i]))};
+          }
+          break;
         case BYTES:
           byte[][] byteValues = blockValSet.getBytesValuesSV();
           for (int i = 0; i < numDocs; i++) {
@@ -314,10 +349,10 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           }
           break;
         default:
-          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
       }
     } else {
-      switch (_storedType) {
+      switch (_dataType) {
         case INT:
           int[][] intValues = blockValSet.getIntValuesMV();
           for (int i = 0; i < numDocs; i++) {
@@ -373,8 +408,19 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
             groupKeys[i] = mvKeys;
           }
           break;
+        case UUID:
+          byte[][][] uuidValues = blockValSet.getBytesValuesMV();
+          for (int i = 0; i < numDocs; i++) {
+            int mvSize = uuidValues[i].length;
+            int[] mvKeys = new int[mvSize];
+            for (int j = 0; j < mvSize; j++) {
+              mvKeys[j] = getKeyForValue(UuidKey.fromBytes(uuidValues[i][j]));
+            }
+            groupKeys[i] = mvKeys;
+          }
+          break;
         default:
-          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
       }
     }
   }
@@ -386,7 +432,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
 
   @Override
   public Iterator<GroupKey> getGroupKeys() {
-    switch (_storedType) {
+    switch (_dataType) {
       case INT:
         return new IntGroupKeyIterator((Int2IntOpenHashMap) _groupKeyMap, _groupIdForNullValue);
       case LONG:
@@ -397,8 +443,9 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         return new DoubleGroupKeyIterator((Double2IntOpenHashMap) _groupKeyMap, _groupIdForNullValue);
       case BIG_DECIMAL:
       case STRING:
+      case UUID:
       case BYTES:
-        return new ObjectGroupKeyIterator((Object2IntOpenHashMap) _groupKeyMap);
+        return new ObjectGroupKeyIterator((Object2IntOpenHashMap) _groupKeyMap, _dataType);
       default:
         throw new IllegalStateException();
     }
@@ -482,6 +529,16 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
 
   private int getKeyForValue(ByteArray value) {
     Object2IntMap<ByteArray> map = (Object2IntMap<ByteArray>) _groupKeyMap;
+    int groupId = map.getInt(value);
+    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
+      groupId = _numGroups++;
+      map.put(value, groupId);
+    }
+    return groupId;
+  }
+
+  private int getKeyForValue(UuidKey value) {
+    Object2IntMap<UuidKey> map = (Object2IntMap<UuidKey>) _groupKeyMap;
     int groupId = map.getInt(value);
     if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
       groupId = _numGroups++;
@@ -638,10 +695,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private static class ObjectGroupKeyIterator implements Iterator<GroupKey> {
     final ObjectIterator<Object2IntMap.Entry> _iterator;
     final GroupKey _groupKey;
+    final DataType _dataType;
 
-    ObjectGroupKeyIterator(Object2IntOpenHashMap objectMap) {
+    ObjectGroupKeyIterator(Object2IntOpenHashMap objectMap, DataType dataType) {
       _iterator = objectMap.object2IntEntrySet().fastIterator();
       _groupKey = new GroupKey();
+      _dataType = dataType;
     }
 
     @Override
@@ -653,7 +712,11 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     public GroupKey next() {
       Object2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
-      _groupKey._keys = new Object[]{entry.getKey()};
+      Object key = entry.getKey();
+      if (_dataType == DataType.UUID && key != null) {
+        key = ((UuidKey) key).toByteArray();
+      }
+      _groupKey._keys = new Object[]{key};
       return _groupKey;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/UuidToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/UuidToIdMap.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.groupby.utils;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+
+
+/**
+ * Implementation of {@link ValueToIdMap} for Pinot's logical UUID type.
+ */
+public class UuidToIdMap implements ValueToIdMap {
+  private final Object2IntOpenHashMap<UuidKey> _valueToIdMap;
+  private final ArrayList<ByteArray> _idToValueMap;
+
+  public UuidToIdMap() {
+    _valueToIdMap = new Object2IntOpenHashMap<>();
+    _valueToIdMap.defaultReturnValue(INVALID_KEY);
+    _idToValueMap = new ArrayList<>();
+  }
+
+  @Override
+  public int put(Object value) {
+    UuidKey uuidKey = UuidKey.fromObject(value);
+    int numValues = _valueToIdMap.size();
+    int id = _valueToIdMap.computeIntIfAbsent(uuidKey, ignored -> numValues);
+    if (id == numValues) {
+      _idToValueMap.add(uuidKey.toByteArray());
+    }
+    return id;
+  }
+
+  @Override
+  public int getId(Object value) {
+    return _valueToIdMap.getInt(UuidKey.fromObject(value));
+  }
+
+  @Override
+  public Object get(int id) {
+    return _idToValueMap.get(id);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/ValueToIdMapFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/ValueToIdMapFactory.java
@@ -38,6 +38,8 @@ public class ValueToIdMapFactory {
         return new FloatToIdMap();
       case DOUBLE:
         return new DoubleToIdMap();
+      case UUID:
+        return new UuidToIdMap();
       default:
         return new ObjectToIdMap();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTable.java
@@ -291,12 +291,13 @@ public class BytesDistinctTable extends DistinctTable {
       rows = new ArrayList<>(numValues);
       addRows(sortedValues, numValues, rows);
     }
+    formatRows(rows);
     return new ResultTable(_dataSchema, rows);
   }
 
   private static void addRows(ByteArray[] values, int length, List<Object[]> rows) {
     for (int i = 0; i < length; i++) {
-      rows.add(new Object[]{values[i].toHexString()});
+      rows.add(new Object[]{values[i]});
     }
   }
 
@@ -312,12 +313,23 @@ public class BytesDistinctTable extends DistinctTable {
       rows = new ArrayList<>(numValues);
       addRows(_valueSet, rows);
     }
+    formatRows(rows);
     return new ResultTable(_dataSchema, rows);
   }
 
   private static void addRows(HashSet<ByteArray> values, List<Object[]> rows) {
     for (ByteArray value : values) {
-      rows.add(new Object[]{value.toHexString()});
+      rows.add(new Object[]{value});
+    }
+  }
+
+  private void formatRows(List<Object[]> rows) {
+    DataSchema.ColumnDataType columnDataType = _dataSchema.getColumnDataType(0);
+    for (Object[] row : rows) {
+      Object value = row[0];
+      if (value != null) {
+        row[0] = columnDataType.convertAndFormat(value);
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -527,6 +527,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
       case STRING:
       case JSON:
         return dataTable.getString(rowId, colId);
+      case UUID:
       case BYTES:
         return dataTable.getBytes(rowId, colId).getBytes();
       default:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunctionTest.java
@@ -20,13 +20,19 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.BitSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -53,6 +59,100 @@ public class DistinctCountHLLAggregationFunctionTest {
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, "8")));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, 8)));
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, "16")));
+  }
+
+  /**
+   * Regression: UUID columns have storedType=BYTES, but a UUID value is a logical scalar, not a serialized
+   * HyperLogLog. The aggregator must route UUID columns through the same content-hash path as STRING (offering
+   * canonical UUID strings) instead of trying to deserialize each 16-byte value as an HLL.
+   */
+  @Test
+  public void testAggregateOnUuidColumnOffersCanonicalStringsAndProducesExactDistinctCount() {
+    ExpressionContext expression = RequestContextUtils.getExpression("uuidCol");
+    DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(List.of(expression));
+
+    // Three distinct UUIDs across six rows; the same UUID repeats twice on rows 0/3, 1/4, 2/5.
+    String[] uuidStrings = new String[]{
+        "550e8400-e29b-41d4-a716-446655440000",
+        "12345678-1234-1234-1234-1234567890ab",
+        "9c5e1f24-0b8e-4c9d-87f1-0aa64a3b9d12",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "12345678-1234-1234-1234-1234567890ab",
+        "9c5e1f24-0b8e-4c9d-87f1-0aa64a3b9d12"
+    };
+
+    // Stub the BYTES fetch (raw 16-byte values) — the production path converts bytes to canonical strings
+    // itself because ProjectionBlockValSet.getStringValuesSV() would render stored BYTES as bare hex.
+    byte[][] uuidBytes = new byte[uuidStrings.length][];
+    for (int i = 0; i < uuidStrings.length; i++) {
+      uuidBytes[i] = UuidUtils.toBytes(uuidStrings[i]);
+    }
+    BlockValSet uuidBlockValSet = mock(BlockValSet.class);
+    when(uuidBlockValSet.getValueType()).thenReturn(DataType.UUID);
+    when(uuidBlockValSet.getBytesValuesSV()).thenReturn(uuidBytes);
+    when(uuidBlockValSet.isSingleValue()).thenReturn(true);
+    when(uuidBlockValSet.getDictionary()).thenReturn(null);
+
+    Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
+    blockValSetMap.put(expression, uuidBlockValSet);
+
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(uuidStrings.length, resultHolder, blockValSetMap);
+
+    Object intermediate = function.extractAggregationResult(resultHolder);
+    Assert.assertTrue(intermediate instanceof HyperLogLog,
+        "Intermediate result must be a HyperLogLog, not a dictionary bitmap");
+    long cardinality = ((HyperLogLog) intermediate).cardinality();
+    Assert.assertEquals(cardinality, 3L,
+        "HLL cardinality must equal the 3 distinct UUIDs; got " + cardinality);
+  }
+
+  /**
+   * Cross-type consistency: DISTINCTCOUNTHLL(uuidCol) must produce the same HLL cardinality as
+   * DISTINCTCOUNTHLL(stringRepresentationOfSameUuids). Locks in the design contract that UUID columns are
+   * hashed as canonical UUID strings.
+   */
+  @Test
+  public void testUuidDistinctCountHllMatchesStringDistinctCountHll() {
+    String[] uuidStrings = new String[]{
+        "550e8400-e29b-41d4-a716-446655440000",
+        "12345678-1234-1234-1234-1234567890ab",
+        "9c5e1f24-0b8e-4c9d-87f1-0aa64a3b9d12"
+    };
+
+    long uuidHllCardinality = computeHllCardinality(uuidStrings, DataType.UUID);
+    long stringHllCardinality = computeHllCardinality(uuidStrings, DataType.STRING);
+
+    Assert.assertEquals(uuidHllCardinality, stringHllCardinality,
+        "DISTINCTCOUNTHLL(uuidCol) must match DISTINCTCOUNTHLL(CAST(uuidCol AS STRING))");
+  }
+
+  private long computeHllCardinality(String[] values, DataType valueType) {
+    ExpressionContext expression = RequestContextUtils.getExpression("col");
+    DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(List.of(expression));
+
+    BlockValSet blockValSet = mock(BlockValSet.class);
+    when(blockValSet.getValueType()).thenReturn(valueType);
+    if (valueType == DataType.UUID) {
+      // UUID path fetches raw bytes and converts to canonical form itself (projection string fetch returns hex)
+      byte[][] uuidBytes = new byte[values.length][];
+      for (int i = 0; i < values.length; i++) {
+        uuidBytes[i] = UuidUtils.toBytes(values[i]);
+      }
+      when(blockValSet.getBytesValuesSV()).thenReturn(uuidBytes);
+    } else {
+      when(blockValSet.getStringValuesSV()).thenReturn(values);
+    }
+    when(blockValSet.isSingleValue()).thenReturn(true);
+    when(blockValSet.getDictionary()).thenReturn(null);
+
+    Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
+    blockValSetMap.put(expression, blockValSet);
+
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(values.length, resultHolder, blockValSetMap);
+    Object intermediate = function.extractAggregationResult(resultHolder);
+    return ((HyperLogLog) intermediate).cardinality();
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -77,12 +79,19 @@ public class NoDictionaryGroupKeyGeneratorTest {
   private static final String STRING_COLUMN = "stringColumn";
   private static final String BYTES_COLUMN = "bytesColumn";
   private static final String BYTES_DICT_COLUMN = "bytesDictColumn";
+  private static final String UUID_COLUMN = "uuidColumn";
+  private static final String BOOLEAN_COLUMN = "booleanColumn";
+  private static final String TIMESTAMP_COLUMN = "timestampColumn";
+  private static final String UUID_DICT_COLUMN = "uuidDictColumn";
   private static final List<String> COLUMNS =
       Arrays.asList(INT_COLUMN, LONG_COLUMN, FLOAT_COLUMN, DOUBLE_COLUMN, STRING_COLUMN, BYTES_COLUMN,
-          BYTES_DICT_COLUMN);
+          BYTES_DICT_COLUMN, UUID_COLUMN, BOOLEAN_COLUMN, TIMESTAMP_COLUMN, UUID_DICT_COLUMN);
   private static final int NUM_COLUMNS = COLUMNS.size();
+  private static final Set<String> UUID_COLUMNS = Set.of(UUID_COLUMN, UUID_DICT_COLUMN);
   private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
-      .setNoDictionaryColumns(COLUMNS.subList(0, NUM_COLUMNS - 1)).build();
+      .setNoDictionaryColumns(
+          List.of(INT_COLUMN, LONG_COLUMN, FLOAT_COLUMN, DOUBLE_COLUMN, STRING_COLUMN, BYTES_COLUMN, UUID_COLUMN,
+              BOOLEAN_COLUMN, TIMESTAMP_COLUMN)).build();
   private static final Schema SCHEMA =
       new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
           .addSingleValueDimension(LONG_COLUMN, FieldSpec.DataType.LONG)
@@ -90,7 +99,11 @@ public class NoDictionaryGroupKeyGeneratorTest {
           .addSingleValueDimension(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE)
           .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
           .addSingleValueDimension(BYTES_COLUMN, FieldSpec.DataType.BYTES)
-          .addSingleValueDimension(BYTES_DICT_COLUMN, FieldSpec.DataType.BYTES).build();
+          .addSingleValueDimension(BYTES_DICT_COLUMN, FieldSpec.DataType.BYTES)
+          .addSingleValueDimension(UUID_COLUMN, FieldSpec.DataType.UUID)
+          .addSingleValueDimension(BOOLEAN_COLUMN, FieldSpec.DataType.BOOLEAN)
+          .addSingleValueDimension(TIMESTAMP_COLUMN, FieldSpec.DataType.TIMESTAMP)
+          .addSingleValueDimension(UUID_DICT_COLUMN, FieldSpec.DataType.UUID).build();
 
   private static final int NUM_RECORDS = 1000;
   private static final int NUM_UNIQUE_RECORDS = 100;
@@ -131,6 +144,19 @@ public class NoDictionaryGroupKeyGeneratorTest {
       record.putValue(BYTES_DICT_COLUMN, bytesValue);
       values[5] = BytesUtils.toHexString(bytesValue);
       values[6] = values[5];
+      byte[] uuidBytes = UuidUtils.toBytes(new UUID(RANDOM.nextLong(), RANDOM.nextLong()));
+      record.putValue(UUID_COLUMN, uuidBytes);
+      values[7] = UuidUtils.toString(uuidBytes);
+      // BOOLEAN stored as INT (0/1) — exercises the logical→stored-type normalization fix
+      int boolIntValue = RANDOM.nextBoolean() ? 1 : 0;
+      record.putValue(BOOLEAN_COLUMN, boolIntValue);
+      values[8] = Integer.toString(boolIntValue);
+      // TIMESTAMP stored as LONG — exercises the logical→stored-type normalization fix
+      long timestampValue = Math.abs(RANDOM.nextLong());
+      record.putValue(TIMESTAMP_COLUMN, timestampValue);
+      values[9] = Long.toString(timestampValue);
+      record.putValue(UUID_DICT_COLUMN, uuidBytes);
+      values[10] = values[7];
       for (int j = 0; j < NUM_RECORDS / NUM_UNIQUE_RECORDS; j++) {
         records.add(record);
       }
@@ -179,9 +205,12 @@ public class NoDictionaryGroupKeyGeneratorTest {
     testGroupKeyGenerator(new int[]{0, 1});
     testGroupKeyGenerator(new int[]{2, 3});
     testGroupKeyGenerator(new int[]{4, 5});
+    testGroupKeyGenerator(new int[]{7, 10});
+    testGroupKeyGenerator(new int[]{8, 9});
     testGroupKeyGenerator(new int[]{1, 2, 3});
     testGroupKeyGenerator(new int[]{4, 5, 0});
-    testGroupKeyGenerator(new int[]{5, 4, 3, 2, 1, 0});
+    testGroupKeyGenerator(new int[]{7, 5, 4});
+    testGroupKeyGenerator(new int[]{7, 5, 4, 3, 2, 1, 0});
   }
 
   /**
@@ -220,7 +249,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
     Iterator<GroupKeyGenerator.GroupKey> groupKeys = groupKeyGenerator.getGroupKeys();
     while (groupKeys.hasNext()) {
       GroupKeyGenerator.GroupKey groupKey = groupKeys.next();
-      assertTrue(expectedGroupKeys.contains(getActualGroupKey(groupKey._keys)));
+      assertTrue(expectedGroupKeys.contains(getActualGroupKey(groupKey._keys, groupByColumnIndexes)));
     }
   }
 
@@ -242,13 +271,18 @@ public class NoDictionaryGroupKeyGeneratorTest {
     return groupKeys;
   }
 
-  private String getActualGroupKey(Object[] groupKeys) {
+  private String getActualGroupKey(Object[] groupKeys, int[] groupByColumnIndexes) {
     StringBuilder stringBuilder = new StringBuilder();
     for (int i = 0; i < groupKeys.length; i++) {
       if (i > 0) {
         stringBuilder.append(GroupKeyGenerator.DELIMITER);
       }
-      stringBuilder.append(groupKeys[i]);
+      int columnIndex = groupByColumnIndexes[i];
+      if (UUID_COLUMNS.contains(COLUMNS.get(columnIndex))) {
+        stringBuilder.append(UuidUtils.toString(((org.apache.pinot.spi.utils.ByteArray) groupKeys[i]).getBytes()));
+      } else {
+        stringBuilder.append(groupKeys[i]);
+      }
     }
     return stringBuilder.toString();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTableTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.distinct.table;
+
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Tests for {@link BytesDistinctTable}.
+ */
+public class BytesDistinctTableTest {
+  private static final String UUID_COLUMN = "uuidCol";
+  private static final String UUID_VALUE_1 = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String UUID_VALUE_2 = "550e8400-e29b-41d4-a716-446655440001";
+
+  @Test
+  public void testToResultTableFormatsUuidAndBytesWithoutOrderBy() {
+    BytesDistinctTable uuidTable = new BytesDistinctTable(
+        new DataSchema(new String[]{UUID_COLUMN}, new ColumnDataType[]{ColumnDataType.UUID}), 10, false, null);
+    uuidTable.addUnbounded(new ByteArray(UuidUtils.toBytes(UUID_VALUE_1)));
+
+    ResultTable uuidResultTable = uuidTable.toResultTable();
+    assertEquals(uuidResultTable.getRows().get(0)[0], UUID_VALUE_1);
+
+    byte[] bytesValue = new byte[]{0x01, 0x23, 0x45};
+    BytesDistinctTable bytesTable = new BytesDistinctTable(
+        new DataSchema(new String[]{"bytesCol"}, new ColumnDataType[]{ColumnDataType.BYTES}), 10, false, null);
+    bytesTable.addUnbounded(new ByteArray(bytesValue));
+
+    ResultTable bytesResultTable = bytesTable.toResultTable();
+    assertEquals(bytesResultTable.getRows().get(0)[0], BytesUtils.toHexString(bytesValue));
+  }
+
+  @Test
+  public void testToResultTableFormatsUuidWithOrderBy() {
+    BytesDistinctTable uuidTable = new BytesDistinctTable(
+        new DataSchema(new String[]{UUID_COLUMN}, new ColumnDataType[]{ColumnDataType.UUID}), 10, false,
+        new OrderByExpressionContext(ExpressionContext.forIdentifier(UUID_COLUMN), true));
+    uuidTable.addUnbounded(new ByteArray(UuidUtils.toBytes(UUID_VALUE_2)));
+    uuidTable.addUnbounded(new ByteArray(UuidUtils.toBytes(UUID_VALUE_1)));
+
+    ResultTable resultTable = uuidTable.toResultTable();
+    assertEquals(resultTable.getRows().get(0)[0], UUID_VALUE_1);
+    assertEquals(resultTable.getRows().get(1)[0], UUID_VALUE_2);
+  }
+}


### PR DESCRIPTION
## What
UUID-aware aggregation and grouping.

## Changes
- `DISTINCTCOUNT`, `DISTINCTCOUNTHLL/HLLPLUS/THETASKETCH/CPCSKETCH/ULL/BITMAP`, `IntegerTupleSketch`, `ANY_VALUE`
- no-dictionary single/multi-column group-key generators, `UuidToIdMap`, `BytesDistinctTable`, `NonScanBasedAggregationOperator`

## Enables
`GROUP BY uuidCol`, `DISTINCT uuidCol`, `DISTINCTCOUNT*(uuidCol)`.

## Depends on
PR 1 and PR 3 (`ColumnDataType.UUID`).

## Why this PR exists
This is **part 5 of 8** splitting [apache/pinot#18140](https://github.com/apache/pinot/pull/18140) (first-class logical `UUID` type) into reviewable, layered PRs, as requested on that PR.

The split is enabled by the v1 design: `DataType.UUID` has **stored type `BYTES`**, so most code paths handle it automatically; each PR adds explicit UUID semantics to one subsystem.

This PR is **stacked on `04-sse-predicates-cast`** (its base branch), so the diff shown here is **only this layer**.

### Full stack (base → top)
1. `uuid-split/01-spi-foundation` — Add logical UUID type foundation (pinot-spi)
2. `uuid-split/02-ingest-storage` — UUID ingest and segment storage
3. `uuid-split/03-result-rendering` — UUID result rendering (DataSchema, Arrow/JSON encoders)
4. `uuid-split/04-sse-predicates-cast` — UUID server-side predicates, CAST and transforms
5. `uuid-split/05-agg-groupby-distinct` — UUID aggregation, group-by and distinct
6. `uuid-split/06-mse-planner-runtime` — UUID multi-stage engine (planner + runtime)
7. `uuid-split/07-udfs-partitioning` — UUID scalar UDFs and partitioning
8. `uuid-split/08-it-bench-docs` — UUID integration tests, benchmarks and docs

Full feature description, v1 design contract, scope exclusions, and benchmark numbers: [apache/pinot#18140](https://github.com/apache/pinot/pull/18140).
