### PR TITLE
[UUID 6/8] UUID multi-stage engine (planner + runtime)

### DIFF
--- a/pinot-common/src/main/proto/expressions.proto
+++ b/pinot-common/src/main/proto/expressions.proto
@@ -44,6 +44,12 @@ enum ColumnDataType {
   UNKNOWN = 19;
   MAP = 20;
   BIG_DECIMAL_ARRAY = 21;
+  // Rolling-upgrade limitation for UUID columns: in a mixed-version multi-stage query, an older broker/server that
+  // does not know UUID = 22 / UUID_ARRAY = 23 will fail planning with UnknownEnumValueException when receiving a plan
+  // that includes a UUID literal. Avoid issuing UUID queries until all brokers and servers are upgraded. See the
+  // matching note on DataSchema.toBytes and ProtoExpressionToRexExpression#convertColumnDataType.
+  UUID = 22;
+  UUID_ARRAY = 23;
 }
 
 message InputRef {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.parsers.ParserUtils;
 
 
@@ -124,7 +125,13 @@ public class CalciteRexExpressionParser {
     if (rexNode instanceof RexExpression.InputRef) {
       return inputRefToIdentifier((RexExpression.InputRef) rexNode, selectList);
     } else if (rexNode instanceof RexExpression.Literal) {
-      return RequestUtils.getLiteralExpression(toLiteral((RexExpression.Literal) rexNode));
+      RexExpression.Literal literal = (RexExpression.Literal) rexNode;
+      if (literal.getDataType() == ColumnDataType.UUID) {
+        return RequestUtils.getFunctionExpression("cast",
+            RequestUtils.getLiteralExpression(UuidUtils.toString((ByteArray) literal.getValue())),
+            RequestUtils.getLiteralExpression("UUID"));
+      }
+      return RequestUtils.getLiteralExpression(toLiteral(literal));
     } else {
       assert rexNode instanceof RexExpression.FunctionCall;
       return compileFunctionExpression((RexExpression.FunctionCall) rexNode, selectList);
@@ -146,6 +153,8 @@ public class CalciteRexExpressionParser {
     ColumnDataType dataType = literal.getDataType();
     if (dataType == ColumnDataType.BOOLEAN) {
       value = BooleanUtils.isTrueInternalValue(value);
+    } else if (dataType == ColumnDataType.UUID) {
+      value = UuidUtils.toString((ByteArray) value);
     } else if (dataType == ColumnDataType.BYTES) {
       value = ((ByteArray) value).getBytes();
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -1174,6 +1174,8 @@ public final class RelToPlanNodeConverter {
       case CHAR:
       case VARCHAR:
         return isArray ? ColumnDataType.STRING_ARRAY : ColumnDataType.STRING;
+      case UUID:
+        return isArray ? ColumnDataType.UUID_ARRAY : ColumnDataType.UUID;
       case BINARY:
       case VARBINARY:
         return isArray ? ColumnDataType.BYTES_ARRAY : ColumnDataType.BYTES;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.plan.RelOptCluster;
@@ -53,6 +54,7 @@ import org.apache.pinot.common.function.scalar.arithmetic.NegateScalarFunction;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,6 +151,9 @@ public class RexExpressionUtils {
         ByteString byteString = new ByteString(bytes);
         return rexBuilder.makeBinaryLiteral(byteString);
       }
+      case UUID:
+        assert value != null;
+        return rexBuilder.makeUuidLiteral(UuidUtils.toUUID((ByteArray) value));
       default:
         throw new IllegalStateException("Unsupported ColumnDataType: " + literal.getDataType());
     }
@@ -263,6 +268,19 @@ public class RexExpressionUtils {
         break;
       case BYTES:
         value = new ByteArray(((ByteString) value).getBytes());
+        break;
+      case UUID:
+        if (value instanceof UUID) {
+          value = new ByteArray(UuidUtils.toBytes((UUID) value));
+        } else if (value instanceof ByteString) {
+          value = new ByteArray(UuidUtils.toBytes(((ByteString) value).getBytes()));
+        } else if (value instanceof NlsString) {
+          value = new ByteArray(UuidUtils.toBytes(((NlsString) value).getValue()));
+        } else if (value instanceof String) {
+          value = new ByteArray(UuidUtils.toBytes((String) value));
+        } else {
+          throw new IllegalStateException("Unsupported value type for UUID: " + value.getClass().getName());
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported ColumnDataType: " + dataType);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
@@ -338,6 +338,8 @@ public class PRelToPlanNodeConverter {
       case CHAR:
       case VARCHAR:
         return isArray ? ColumnDataType.STRING_ARRAY : ColumnDataType.STRING;
+      case UUID:
+        return isArray ? ColumnDataType.UUID_ARRAY : ColumnDataType.UUID;
       case BINARY:
       case VARBINARY:
         return isArray ? ColumnDataType.BYTES_ARRAY : ColumnDataType.BYTES;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
@@ -146,6 +146,7 @@ public class ProtoExpressionToRexExpression {
         }
         return new RexExpression.Literal(dataType, values);
       }
+      // NOTE: UUID_ARRAY's stored type is BYTES_ARRAY, so this case handles both.
       case BYTES_ARRAY: {
         Expressions.BytesArray bytesArray = literal.getBytesArray();
         int numValues = bytesArray.getValuesCount();
@@ -182,6 +183,10 @@ public class ProtoExpressionToRexExpression {
         return ColumnDataType.JSON;
       case BYTES:
         return ColumnDataType.BYTES;
+      case UUID:
+        return ColumnDataType.UUID;
+      case UUID_ARRAY:
+        return ColumnDataType.UUID_ARRAY;
       case INT_ARRAY:
         return ColumnDataType.INT_ARRAY;
       case LONG_ARRAY:
@@ -207,6 +212,10 @@ public class ProtoExpressionToRexExpression {
       case UNKNOWN:
         return ColumnDataType.UNKNOWN;
       default:
+        // Rolling-upgrade limitation for UUID columns: an older broker/server that does not know UUID = 22 /
+        // UUID_ARRAY = 23 from expressions.proto will land here with UNRECOGNIZED and throw. Avoid issuing UUID
+        // queries until all brokers and servers are upgraded. See the matching note on expressions.proto and
+        // DataSchema.toBytes.
         throw new IllegalStateException("Unsupported proto ColumnDataType: " + dataType);
     }
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
@@ -132,6 +132,7 @@ public class RexExpressionToProtoExpression {
           literalBuilder.setStringArray(
               Expressions.StringArray.newBuilder().addAllValues(Arrays.asList((String[]) value)).build());
           break;
+        // NOTE: UUID_ARRAY's stored type is BYTES_ARRAY, so this case handles both.
         case BYTES_ARRAY: {
           ByteArray[] bytesArray = (ByteArray[]) value;
           Expressions.BytesArray.Builder builder = Expressions.BytesArray.newBuilder();
@@ -170,6 +171,10 @@ public class RexExpressionToProtoExpression {
         return Expressions.ColumnDataType.JSON;
       case BYTES:
         return Expressions.ColumnDataType.BYTES;
+      case UUID:
+        return Expressions.ColumnDataType.UUID;
+      case UUID_ARRAY:
+        return Expressions.ColumnDataType.UUID_ARRAY;
       case MAP:
         return Expressions.ColumnDataType.MAP;
       case INT_ARRAY:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -102,6 +102,8 @@ public class TypeFactory extends JavaTypeFactoryImpl {
       case STRING:
       case JSON:
         return SqlTypeName.VARCHAR;
+      case UUID:
+        return SqlTypeName.UUID;
       case BYTES:
         return SqlTypeName.VARBINARY;
       case BIG_DECIMAL:

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/parser/CalciteRexExpressionParserTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/parser/CalciteRexExpressionParserTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.parser;
+
+import java.util.List;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+
+public class CalciteRexExpressionParserTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
+  @Test
+  public void testToExpressionPreservesUuidLiteralAsCast() {
+    RexExpression.Literal uuidLiteral =
+        new RexExpression.Literal(ColumnDataType.UUID, new ByteArray(UuidUtils.toBytes(UUID_VALUE)));
+
+    Expression expression = CalciteRexExpressionParser.toExpression(uuidLiteral, List.of());
+
+    assertNull(expression.getLiteral());
+    Function function = expression.getFunctionCall();
+    assertNotNull(function);
+    assertEquals(function.getOperator(), "cast");
+    assertEquals(function.getOperandsSize(), 2);
+    assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), UUID_VALUE);
+    assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "UUID");
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
@@ -50,6 +50,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalEnrichedJoin;
 import org.apache.pinot.calcite.rel.rules.PinotEnrichedJoinRule;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.physical.v2.PRelToPlanNodeConverter;
 import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
 import org.apache.pinot.query.planner.plannode.FilterNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
@@ -140,6 +141,13 @@ public class RelToPlanNodeConverterTest {
   }
 
   @Test
+  public void testConvertToColumnDataTypeForUUID() {
+    RelDataType uuidType = new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.UUID);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(uuidType), DataSchema.ColumnDataType.UUID);
+    Assert.assertEquals(PRelToPlanNodeConverter.convertToColumnDataType(uuidType), DataSchema.ColumnDataType.UUID);
+  }
+
+  @Test
   public void testConvertToColumnDataTypeForArray() {
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ArraySqlType(new ObjectSqlType(SqlTypeName.BOOLEAN, SqlIdentifier.STAR, true, null, null), true)),
@@ -180,6 +188,17 @@ public class RelToPlanNodeConverterTest {
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ArraySqlType(new ObjectSqlType(SqlTypeName.VARBINARY, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.BYTES_ARRAY);
+  }
+
+  @Test
+  public void testConvertToColumnDataTypeForUUIDArray() {
+    RelDataType uuidArrayType =
+        new ArraySqlType(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.UUID), true);
+
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(uuidArrayType),
+        DataSchema.ColumnDataType.UUID_ARRAY);
+    Assert.assertEquals(PRelToPlanNodeConverter.convertToColumnDataType(uuidArrayType),
+        DataSchema.ColumnDataType.UUID_ARRAY);
   }
 
   @Test

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -35,10 +36,13 @@ public class RexExpressionSerDeTest {
   private static final List<ColumnDataType> SUPPORTED_DATE_TYPES =
       List.of(ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.FLOAT, ColumnDataType.DOUBLE,
           ColumnDataType.BIG_DECIMAL, ColumnDataType.BOOLEAN, ColumnDataType.TIMESTAMP, ColumnDataType.STRING,
-          ColumnDataType.BYTES, ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY, ColumnDataType.FLOAT_ARRAY,
+          ColumnDataType.UUID, ColumnDataType.BYTES, ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY,
+          ColumnDataType.FLOAT_ARRAY,
           ColumnDataType.DOUBLE_ARRAY, ColumnDataType.BOOLEAN_ARRAY, ColumnDataType.TIMESTAMP_ARRAY,
-          ColumnDataType.STRING_ARRAY, ColumnDataType.UNKNOWN);
+          ColumnDataType.STRING_ARRAY, ColumnDataType.BYTES_ARRAY, ColumnDataType.UUID_ARRAY,
+          ColumnDataType.UNKNOWN);
   private static final Random RANDOM = new Random();
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
 
   @Test
   public void testNullLiteral() {
@@ -94,6 +98,17 @@ public class RexExpressionSerDeTest {
     byte[] bytes = new byte[RANDOM.nextInt(10)];
     RANDOM.nextBytes(bytes);
     verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.BYTES, new ByteArray(bytes)));
+  }
+
+  @Test
+  public void testUuidLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.UUID, new ByteArray(UuidUtils.toBytes(UUID_VALUE))));
+  }
+
+  @Test
+  public void testUuidArrayLiteral() {
+    ByteArray[] values = {new ByteArray(UuidUtils.toBytes(UUID_VALUE))};
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.UUID_ARRAY, values));
   }
 
   @Test

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
@@ -104,6 +104,10 @@ public class TypeFactoryTest {
           basicType = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
           break;
         }
+        case UUID: {
+          basicType = TYPE_FACTORY.createSqlType(SqlTypeName.UUID);
+          break;
+        }
         case BYTES: {
           basicType = TYPE_FACTORY.createSqlType(SqlTypeName.VARBINARY);
           break;
@@ -180,6 +184,9 @@ public class TypeFactoryTest {
 
   @Test(dataProvider = "relDataTypeConversion")
   public void testArrayTypes(FieldSpec.DataType dataType, RelDataType arrayType, boolean columnNullMode) {
+    if (dataType == FieldSpec.DataType.BIG_DECIMAL || dataType == FieldSpec.DataType.JSON) {
+      return;
+    }
     TypeFactory typeFactory = new TypeFactory();
     Schema testSchema = new Schema.SchemaBuilder()
         .addMultiValueDimension("col", dataType)
@@ -198,6 +205,9 @@ public class TypeFactoryTest {
 
   @Test(dataProvider = "relDataTypeConversion")
   public void testNullableArrayTypes(FieldSpec.DataType dataType, RelDataType arrayType, boolean columnNullMode) {
+    if (dataType == FieldSpec.DataType.BIG_DECIMAL || dataType == FieldSpec.DataType.JSON) {
+      return;
+    }
     TypeFactory typeFactory = new TypeFactory();
     Schema testSchema = new Schema.SchemaBuilder()
         .addDimensionField("col", dataType, field -> {
@@ -219,6 +229,9 @@ public class TypeFactoryTest {
 
   @Test(dataProvider = "relDataTypeConversion")
   public void testNotNullableArrayTypes(FieldSpec.DataType dataType, RelDataType arrayType, boolean columnNullMode) {
+    if (dataType == FieldSpec.DataType.BIG_DECIMAL || dataType == FieldSpec.DataType.JSON) {
+      return;
+    }
     TypeFactory typeFactory = new TypeFactory();
     Schema testSchema = new Schema.SchemaBuilder()
         .addDimensionField("col", dataType, field -> {
@@ -244,6 +257,7 @@ public class TypeFactoryTest {
         .addSingleValueDimension("FLOAT_COL", FieldSpec.DataType.FLOAT)
         .addSingleValueDimension("DOUBLE_COL", FieldSpec.DataType.DOUBLE)
         .addSingleValueDimension("STRING_COL", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("UUID_COL", FieldSpec.DataType.UUID)
         .addSingleValueDimension("BYTES_COL", FieldSpec.DataType.BYTES)
         .addSingleValueDimension("JSON_COL", FieldSpec.DataType.JSON)
         .addMultiValueDimension("INT_ARRAY_COL", FieldSpec.DataType.INT)
@@ -251,6 +265,7 @@ public class TypeFactoryTest {
         .addMultiValueDimension("FLOAT_ARRAY_COL", FieldSpec.DataType.FLOAT)
         .addMultiValueDimension("DOUBLE_ARRAY_COL", FieldSpec.DataType.DOUBLE)
         .addMultiValueDimension("STRING_ARRAY_COL", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("UUID_ARRAY_COL", FieldSpec.DataType.UUID)
         .addMultiValueDimension("BYTES_ARRAY_COL", FieldSpec.DataType.BYTES)
         .build();
     RelDataType relDataTypeFromSchema = typeFactory.createRelDataTypeFromSchema(testSchema);
@@ -283,6 +298,9 @@ public class TypeFactoryTest {
               TYPE_FACTORY.createTypeWithCharsetAndCollation(new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.VARCHAR),
                   StandardCharsets.UTF_8, SqlCollation.IMPLICIT));
           break;
+        case "UUID_COL":
+          Assert.assertEquals(field.getType(), new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.UUID));
+          break;
         case "BYTES_COL":
           Assert.assertEquals(field.getType(), new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.VARBINARY));
           break;
@@ -306,6 +324,10 @@ public class TypeFactoryTest {
           Assert.assertEquals(field.getType(), new ArraySqlType(
               TYPE_FACTORY.createTypeWithCharsetAndCollation(new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.VARCHAR),
                   StandardCharsets.UTF_8, SqlCollation.IMPLICIT), false));
+          break;
+        case "UUID_ARRAY_COL":
+          Assert.assertEquals(field.getType(),
+              new ArraySqlType(new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.UUID), false));
           break;
         case "BYTES_ARRAY_COL":
           Assert.assertEquals(field.getType(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/EnrichedHashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/EnrichedHashJoinOperator.java
@@ -277,7 +277,10 @@ public class EnrichedHashJoinOperator extends HashJoinOperator {
     ArrayList<Object[]> rows = new ArrayList<>(leftRows.size());
 
     for (Object[] leftRow : leftRows) {
-      Object key = _leftKeySelector.getKey(leftRow);
+      // Normalize the key for table-specific lookup semantics (e.g. UuidLookupTable expects a UuidKey, not the
+      // raw ByteArray from the row). Mirrors HashJoinOperator. Also store the normalized key in
+      // _matchedRightRows so buildNonMatchRightRows can read it back with the same shape.
+      Object key = _rightTable.normalizeKey(_leftKeySelector.getKey(leftRow));
       Object[] rightRow = (Object[]) _rightTable.lookup(key);
       if (rightRow == null) {
         handleUnmatchedLeftRow(leftRow, rows);
@@ -307,7 +310,8 @@ public class EnrichedHashJoinOperator extends HashJoinOperator {
     List<Object[]> rows = new ArrayList<>(leftRows.size());
 
     for (Object[] leftRow : leftRows) {
-      Object key = _leftKeySelector.getKey(leftRow);
+      // See buildJoinedDataBlockUniqueKeys for why the key must be normalized.
+      Object key = _rightTable.normalizeKey(_leftKeySelector.getKey(leftRow));
       List<Object[]> rightRows = (List<Object[]>) _rightTable.lookup(key);
       if (rightRows == null) {
         handleUnmatchedLeftRow(leftRow, rows);
@@ -348,8 +352,9 @@ public class EnrichedHashJoinOperator extends HashJoinOperator {
     List<Object[]> rows = new ArrayList<>(leftRows.size());
 
     for (Object[] leftRow : leftRows) {
-      Object key = _leftKeySelector.getKey(leftRow);
-      // ANTI-JOIN only checks non-existence of the key
+      // ANTI-JOIN only checks non-existence of the key. Normalize so UuidLookupTable (and any future custom
+      // lookup table whose normalization is not identity) can answer correctly.
+      Object key = _rightTable.normalizeKey(_leftKeySelector.getKey(leftRow));
       if (!_rightTable.containsKey(key)) {
         filterProjectLimit(leftRow, null, rows, _leftColumnSize, _leftColumnSize);
       }
@@ -364,8 +369,8 @@ public class EnrichedHashJoinOperator extends HashJoinOperator {
     List<Object[]> rows = new ArrayList<>(leftRows.size());
 
     for (Object[] leftRow : leftRows) {
-      Object key = _leftKeySelector.getKey(leftRow);
-      // SEMI-JOIN only checks existence of the key
+      // SEMI-JOIN only checks existence of the key (normalized — see ANTI-JOIN above).
+      Object key = _rightTable.normalizeKey(_leftKeySelector.getKey(leftRow));
       if (_rightTable.containsKey(key)) {
         filterProjectLimit(leftRow, null, rows, _leftColumnSize, _leftColumnSize);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
@@ -38,6 +39,7 @@ import org.apache.pinot.query.runtime.operator.join.IntLookupTable;
 import org.apache.pinot.query.runtime.operator.join.LongLookupTable;
 import org.apache.pinot.query.runtime.operator.join.LookupTable;
 import org.apache.pinot.query.runtime.operator.join.ObjectLookupTable;
+import org.apache.pinot.query.runtime.operator.join.UuidLookupTable;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 
 
@@ -97,7 +99,11 @@ public class HashJoinOperator extends BaseJoinOperator {
     if (joinKeys.size() > 1) {
       return new ObjectLookupTable();
     }
-    switch (schema.getColumnDataType(joinKeys.get(0)).getStoredType()) {
+    ColumnDataType columnDataType = schema.getColumnDataType(joinKeys.get(0));
+    if (columnDataType == ColumnDataType.UUID) {
+      return new UuidLookupTable();
+    }
+    switch (columnDataType.getStoredType()) {
       case INT:
         return new IntLookupTable();
       case LONG:
@@ -207,7 +213,8 @@ public class HashJoinOperator extends BaseJoinOperator {
       if (handleNullKey(key, leftRow, rows)) {
         continue;
       }
-      Object[] rightRow = (Object[]) _rightTable.lookup(key);
+      Object normalizedKey = _rightTable.normalizeKey(key);
+      Object[] rightRow = (Object[]) _rightTable.lookup(normalizedKey);
       if (rightRow == null) {
         handleUnmatchedLeftRow(leftRow, rows);
       } else {
@@ -220,7 +227,7 @@ public class HashJoinOperator extends BaseJoinOperator {
           checkTerminationAndSampleUsagePeriodically(rows.size(), BUILD_JOINED_ROWS_SCOPE);
           rows.add(resultRowView.toArray());
           if (_matchedRightRows != null) {
-            _matchedRightRows.put(key, BIT_SET_PLACEHOLDER);
+            _matchedRightRows.put(normalizedKey, BIT_SET_PLACEHOLDER);
           }
         } else {
           handleUnmatchedLeftRow(leftRow, rows);
@@ -242,7 +249,8 @@ public class HashJoinOperator extends BaseJoinOperator {
       if (handleNullKey(key, leftRow, rows)) {
         continue;
       }
-      List<Object[]> rightRows = (List<Object[]>) _rightTable.lookup(key);
+      Object normalizedKey = _rightTable.normalizeKey(key);
+      List<Object[]> rightRows = (List<Object[]>) _rightTable.lookup(normalizedKey);
       if (rightRows == null) {
         handleUnmatchedLeftRow(leftRow, rows);
       } else {
@@ -260,7 +268,7 @@ public class HashJoinOperator extends BaseJoinOperator {
             rows.add(resultRowView.toArray());
             hasMatchForLeftRow = true;
             if (_matchedRightRows != null) {
-              _matchedRightRows.computeIfAbsent(key, k -> new BitSet(numRightRows)).set(i);
+              _matchedRightRows.computeIfAbsent(normalizedKey, k -> new BitSet(numRightRows)).set(i);
             }
           }
         }
@@ -293,7 +301,7 @@ public class HashJoinOperator extends BaseJoinOperator {
 
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
-      if (_rightTable.containsKey(key)) {
+      if (_rightTable.containsKey(_rightTable.normalizeKey(key))) {
         checkTerminationAndSampleUsagePeriodically(rows.size(), BUILD_JOINED_ROWS_SCOPE);
         rows.add(leftRow);
       }
@@ -309,7 +317,7 @@ public class HashJoinOperator extends BaseJoinOperator {
 
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
-      if (!_rightTable.containsKey(key)) {
+      if (!_rightTable.containsKey(_rightTable.normalizeKey(key))) {
         checkTerminationAndSampleUsagePeriodically(rows.size(), BUILD_JOINED_ROWS_SCOPE);
         rows.add(leftRow);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
@@ -38,6 +38,8 @@ public class GroupIdGeneratorFactory {
           return new OneFloatKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         case DOUBLE:
           return new OneDoubleKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
+        case UUID:
+          return new OneUuidKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         default:
           return new OneObjectKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneUuidKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneUuidKeyGroupIdGenerator.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.groupby;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import java.util.Iterator;
+import java.util.function.ToIntFunction;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+
+
+/**
+ * Group-id generator for a single UUID group-by key in the multi-stage engine. Normalizes every incoming key
+ * ({@code byte[]}, {@code ByteArray}, {@code String} or {@code UuidKey}) to {@link UuidKey} — two primitive longs —
+ * so map probing avoids byte-array hashing/equality on the hot path. Not thread-safe; each instance is owned by a
+ * single operator thread, matching the other {@link GroupIdGenerator} implementations.
+ */
+public class OneUuidKeyGroupIdGenerator implements GroupIdGenerator {
+  private final Object2IntOpenHashMap<Object> _groupIdMap;
+  private final int _numGroupsLimit;
+  private final ToIntFunction<Object> _groupIdGenerator;
+
+  public OneUuidKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Object2IntOpenHashMap<>(initialCapacity);
+    _groupIdMap.defaultReturnValue(INVALID_ID);
+    _numGroupsLimit = numGroupsLimit;
+    _groupIdGenerator = ignored -> _groupIdMap.size();
+  }
+
+  @Override
+  public int getGroupId(Object key) {
+    Object normalizedKey = key != null ? UuidKey.fromObject(key) : null;
+    if (_groupIdMap.size() < _numGroupsLimit) {
+      return _groupIdMap.computeIfAbsent(normalizedKey, _groupIdGenerator);
+    } else {
+      return _groupIdMap.getInt(normalizedKey);
+    }
+  }
+
+  @Override
+  public int getNumGroups() {
+    return _groupIdMap.size();
+  }
+
+  @Override
+  public Iterator<GroupKey> getGroupKeyIterator(int numColumns) {
+    return new Iterator<GroupKey>() {
+      final ObjectIterator<Object2IntOpenHashMap.Entry<Object>> _entryIterator =
+          _groupIdMap.object2IntEntrySet().fastIterator();
+
+      @Override
+      public boolean hasNext() {
+        return _entryIterator.hasNext();
+      }
+
+      @Override
+      public GroupKey next() {
+        Object2IntMap.Entry<Object> entry = _entryIterator.next();
+        Object[] row = new Object[numColumns];
+        Object key = entry.getKey();
+        row[0] = key != null ? ((UuidKey) key).toByteArray() : null;
+        return new GroupKey(entry.getIntValue(), row);
+      }
+    };
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -60,6 +60,14 @@ public abstract class LookupTable {
    */
   public abstract void finish();
 
+  /**
+   * Normalizes a join key into the internal lookup-table key shape.
+   */
+  @Nullable
+  public Object normalizeKey(@Nullable Object key) {
+    return key;
+  }
+
   protected static void convertValueToList(Map.Entry<?, Object> entry) {
     Object value = entry.getValue();
     if (value instanceof Object[]) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/UuidLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/UuidLookupTable.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+
+
+/**
+ * Lookup table optimized for Pinot's logical UUID type — stores entries keyed by
+ * {@link org.apache.pinot.spi.utils.UuidUtils.UuidKey} (two primitive longs) so the hot path avoids
+ * {@code ByteArray} wrapping/equals.
+ *
+ * <p><b>Contract:</b> {@link #addRow} normalizes the supplied key implicitly via
+ * {@link #normalizeKey(Object)}; {@link #containsKey} and {@link #lookup} do NOT — callers must pass an
+ * already-normalized key (the join operators do this via {@code _rightTable.normalizeKey(...)}). Passing a
+ * raw {@code byte[]}, {@code String}, or {@code ByteArray} to {@link #containsKey} / {@link #lookup} will
+ * silently miss because the table is keyed on {@code UuidKey}, whose equality is by primitive longs.
+ */
+@SuppressWarnings("unchecked")
+public class UuidLookupTable extends LookupTable {
+  private final Map<Object, Object> _lookupTable = Maps.newHashMapWithExpectedSize(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(@Nullable Object key, Object[] row) {
+    Object normalizedKey = normalizeKey(key);
+    if (normalizedKey == null) {
+      return;
+    }
+    _lookupTable.compute(normalizedKey, (k, v) -> computeNewValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Map.Entry<Object, Object> entry : _lookupTable.entrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object normalizeKey(@Nullable Object key) {
+    return key != null ? UuidKey.fromObject(key) : null;
+  }
+
+  @Override
+  public boolean containsKey(@Nullable Object key) {
+    return key != null && _lookupTable.containsKey(key);
+  }
+
+  @Nullable
+  @Override
+  public Object lookup(@Nullable Object key) {
+    return key != null ? _lookupTable.get(key) : null;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry<Object, Object>> entrySet() {
+    return _lookupTable.entrySet();
+  }
+
+  @Override
+  public int size() {
+    return _lookupTable.size();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -60,6 +60,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.rewriter.NonAggregationGroupByToDistinctQueryRewriter;
@@ -412,7 +413,11 @@ public class ServerPlanRequestUtils {
         }
         Arrays.sort(arrBytes);
         for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
-          expressions.add(RequestUtils.getLiteralExpression(arrBytes[rowIdx].getBytes()));
+          if (columnDataType == DataSchema.ColumnDataType.UUID) {
+            expressions.add(RequestUtils.getLiteralExpression(UuidUtils.toString(arrBytes[rowIdx])));
+          } else {
+            expressions.add(RequestUtils.getLiteralExpression(arrBytes[rowIdx].getBytes()));
+          }
         }
         break;
       default:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/EnrichedHashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/EnrichedHashJoinOperatorTest.java
@@ -23,11 +23,14 @@ import java.util.List;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -39,6 +42,16 @@ public class EnrichedHashJoinOperatorTest {
   private MultiStageOperator _rightInput;
   private static final DataSchema DEFAULT_CHILD_SCHEMA = new DataSchema(new String[]{"int_col", "string_col"},
       new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
+
+  private static final ByteArray UUID_A = uuid("550e8400-e29b-41d4-a716-446655440000");
+  private static final ByteArray UUID_B = uuid("550e8400-e29b-41d4-a716-446655440001");
+  private static final ByteArray UUID_C = uuid("550e8400-e29b-41d4-a716-446655440002");
+  private static final DataSchema UUID_CHILD_SCHEMA = new DataSchema(new String[]{"uuid_col", "int_col"},
+      new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.INT});
+
+  private static ByteArray uuid(String value) {
+    return new ByteArray(UuidUtils.toBytes(value));
+  }
 
   @Test
   public void shouldHandleBasicInnerJoin() {
@@ -577,6 +590,63 @@ public class EnrichedHashJoinOperatorTest {
     assertEquals(resultRows.size(), 2);
     assertEquals(resultRows.get(0)[1], "BB");
     assertEquals(resultRows.get(1), new Object[]{null, null, 4, "Bd"});
+  }
+
+  /**
+   * Regression: {@link EnrichedHashJoinOperator} overrides {@code buildJoinedDataBlock*} from
+   * {@link HashJoinOperator}. Without re-applying {@code _rightTable.normalizeKey(...)} in the overrides, a
+   * UUID equi-join would lookup the {@link org.apache.pinot.query.runtime.operator.join.UuidLookupTable} with
+   * the raw {@code ByteArray} from the row, never match (the table is keyed by
+   * {@link org.apache.pinot.spi.utils.UuidUtils.UuidKey}), and INNER joins would silently return zero rows.
+   */
+  @Test
+  public void shouldHandleInnerJoinOnUuid() {
+    _leftInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_A, 1)
+        .addRow(UUID_B, 2)
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_B, 20)
+        .addRow(UUID_C, 30)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"uuid_col1", "int_col1", "uuid_col2", "int_col2"},
+        new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.INT, ColumnDataType.UUID, ColumnDataType.INT});
+
+    HashJoinOperator operator =
+        getOperator(UUID_CHILD_SCHEMA, resultSchema, JoinRelType.INNER, List.of(0), List.of(0),
+            List.of(), PlanNode.NodeHint.EMPTY, null, null, null);
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows.size(), 1, "UUID equi-join must produce the single matching row");
+    assertEquals(resultRows.get(0), new Object[]{UUID_B, 2, UUID_B, 20});
+  }
+
+  /**
+   * Regression: SEMI-join on UUID exercises the {@code _rightTable.containsKey} path in the override; with the
+   * raw-key bug, SEMI-join returned zero rows for every left row.
+   */
+  @Test
+  public void shouldHandleSemiJoinOnUuid() {
+    _leftInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_A, 1)
+        .addRow(UUID_B, 2)
+        .addRow(UUID_C, 3)
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_B, 20)
+        .addRow(UUID_C, 30)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"uuid_col", "int_col"},
+        new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.INT});
+
+    HashJoinOperator operator =
+        getOperator(UUID_CHILD_SCHEMA, resultSchema, JoinRelType.SEMI, List.of(0), List.of(0),
+            List.of(), PlanNode.NodeHint.EMPTY, null, null, null);
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows.size(), 2, "SEMI-join on UUID must emit left rows whose key exists in the right table");
+    assertEquals(resultRows.get(0), new Object[]{UUID_B, 2});
+    assertEquals(resultRows.get(1), new Object[]{UUID_C, 3});
   }
 
   // utils ----

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -32,6 +32,8 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
@@ -47,6 +49,9 @@ import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 
 public class HashJoinOperatorTest {
+  private static final ByteArray UUID_A = uuid("550e8400-e29b-41d4-a716-446655440000");
+  private static final ByteArray UUID_B = uuid("550e8400-e29b-41d4-a716-446655440001");
+  private static final ByteArray UUID_C = uuid("550e8400-e29b-41d4-a716-446655440002");
   private AutoCloseable _mocks;
   private MultiStageOperator _leftInput;
   private MultiStageOperator _rightInput;
@@ -55,6 +60,8 @@ public class HashJoinOperatorTest {
 
   private static final DataSchema DEFAULT_CHILD_SCHEMA = new DataSchema(new String[]{"int_col", "string_col"},
       new ColumnDataType[] {ColumnDataType.INT, ColumnDataType.STRING});
+  private static final DataSchema UUID_CHILD_SCHEMA = new DataSchema(new String[]{"uuid_col", "int_col"},
+      new ColumnDataType[] {ColumnDataType.UUID, ColumnDataType.INT});
   @BeforeMethod
   public void setUp() {
     _mocks = openMocks(this);
@@ -112,6 +119,34 @@ public class HashJoinOperatorTest {
         OperatorTestUtil.getStatMap(HashJoinOperator.StatKey.class, operator.calculateStats());
     assertEquals(statMap.getLong(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN), 3,
         "Max rows in join should equal right table size");
+  }
+
+  @Test
+  public void shouldHandleRightJoinOnUuid() {
+    _leftInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_A, 1)
+        .addRow(UUID_B, 2)
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_B, 20)
+        .addRow(UUID_B, 21)
+        .addRow(UUID_C, 30)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"uuid_col1", "int_col1", "uuid_col2", "int_col2"},
+        new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.INT, ColumnDataType.UUID, ColumnDataType.INT});
+
+    HashJoinOperator operator = getOperator(UUID_CHILD_SCHEMA, resultSchema, JoinRelType.RIGHT, List.of(0), List.of(0),
+        List.of(), PlanNode.NodeHint.EMPTY);
+
+    List<Object[]> resultRows1 = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows1.size(), 2);
+    assertTrue(containsRow(resultRows1, new Object[]{UUID_B, 2, UUID_B, 20}));
+    assertTrue(containsRow(resultRows1, new Object[]{UUID_B, 2, UUID_B, 21}));
+
+    List<Object[]> resultRows2 = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows2.size(), 1);
+    assertTrue(containsRow(resultRows2, new Object[]{null, null, UUID_C, 30}));
+    assertTrue(operator.nextBlock().isSuccess());
   }
 
   @Test
@@ -568,6 +603,10 @@ public class HashJoinOperatorTest {
       }
     }
     return false;
+  }
+
+  private static ByteArray uuid(String value) {
+    return new ByteArray(UuidUtils.toBytes(value));
   }
 
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtilsTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.plan.server;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for {@link ServerPlanRequestUtils}.
+ */
+public class ServerPlanRequestUtilsTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
+  /**
+   * Regression test for the UUID IN-predicate literal fix.
+   *
+   * Before the fix, UUID ByteArray values were passed as raw byte[] literals into the dynamic filter.
+   * The server-side predicate evaluator expected a canonical UUID string, so the filter never matched
+   * and UUID join queries silently returned no rows.
+   *
+   * After the fix, UUID values are emitted as canonical lowercase string literals.
+   */
+  @Test
+  public void testComputeInOperandsUuidEmitsStringLiterals()
+      throws Exception {
+    DataSchema schema = new DataSchema(new String[]{"uuidCol"}, new ColumnDataType[]{ColumnDataType.UUID});
+
+    List<Object[]> dataContainer = new ArrayList<>();
+    dataContainer.add(new Object[]{new ByteArray(UuidUtils.toBytes(UUID_VALUE))});
+
+    List<Expression> expressions = invokeComputeInOperands(dataContainer, schema, 0);
+
+    assertEquals(expressions.size(), 1);
+    Expression expr = expressions.get(0);
+    assertNotNull(expr.getLiteral(), "UUID operand must be a literal expression");
+    // Must be a string literal containing the canonical UUID, not a byte array literal
+    assertTrue(expr.getLiteral().isSetStringValue(),
+        "UUID literal must be a string, not bytes. Got: " + expr.getLiteral());
+    assertEquals(expr.getLiteral().getStringValue(), UUID_VALUE,
+        "UUID literal value must be canonical lowercase RFC 4122 string");
+  }
+
+  /**
+   * Verifies that raw BYTES columns still emit byte-array literals (unchanged behavior).
+   */
+  @Test
+  public void testComputeInOperandsBytesEmitsByteArrayLiterals()
+      throws Exception {
+    DataSchema schema = new DataSchema(new String[]{"bytesCol"}, new ColumnDataType[]{ColumnDataType.BYTES});
+    byte[] rawBytes = {0x01, 0x02, 0x03};
+
+    List<Object[]> dataContainer = new ArrayList<>();
+    dataContainer.add(new Object[]{new ByteArray(rawBytes)});
+
+    List<Expression> expressions = invokeComputeInOperands(dataContainer, schema, 0);
+
+    assertEquals(expressions.size(), 1);
+    Expression expr = expressions.get(0);
+    assertNotNull(expr.getLiteral(), "BYTES operand must be a literal expression");
+    assertTrue(expr.getLiteral().isSetBinaryValue(),
+        "BYTES literal must be binary, not string. Got: " + expr.getLiteral());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Expression> invokeComputeInOperands(List<Object[]> dataContainer, DataSchema dataSchema,
+      int colIdx)
+      throws Exception {
+    Method method = ServerPlanRequestUtils.class.getDeclaredMethod("computeInOperands", List.class, DataSchema.class,
+        int.class);
+    method.setAccessible(true);
+    return (List<Expression>) method.invoke(null, dataContainer, dataSchema, colIdx);
+  }
+}


### PR DESCRIPTION
## What
Multi-stage (v2) engine support for UUID.

## Changes
- `expressions.proto` UUID / UUID_ARRAY enum values + planner type resolution, Rex parsing, proto serde, `TypeFactory`
- `HashJoinOperator` / `EnrichedHashJoinOperator` + `UuidLookupTable` (`LookupTable.normalizeKey`), `OneUuidKeyGroupIdGenerator`, `ServerPlanRequestUtils`

## Enables
UUID equi-joins and group-by in the multi-stage engine.

⚠️ **Rolling-upgrade note:** the new proto enum values are unknown to older brokers/servers; multi-stage queries with UUID literals fail on mixed-version clusters. Atomic-upgrade feature.

## Depends on
PR 1 and PR 3.

## Why this PR exists
This is **part 6 of 8** splitting [apache/pinot#18140](https://github.com/apache/pinot/pull/18140) (first-class logical `UUID` type) into reviewable, layered PRs, as requested on that PR.

The split is enabled by the v1 design: `DataType.UUID` has **stored type `BYTES`**, so most code paths handle it automatically; each PR adds explicit UUID semantics to one subsystem.

This PR is **stacked on `05-agg-groupby-distinct`** (its base branch), so the diff shown here is **only this layer**.

### Full stack (base → top)
1. `uuid-split/01-spi-foundation` — Add logical UUID type foundation (pinot-spi)
2. `uuid-split/02-ingest-storage` — UUID ingest and segment storage
3. `uuid-split/03-result-rendering` — UUID result rendering (DataSchema, Arrow/JSON encoders)
4. `uuid-split/04-sse-predicates-cast` — UUID server-side predicates, CAST and transforms
5. `uuid-split/05-agg-groupby-distinct` — UUID aggregation, group-by and distinct
6. `uuid-split/06-mse-planner-runtime` — UUID multi-stage engine (planner + runtime)
7. `uuid-split/07-udfs-partitioning` — UUID scalar UDFs and partitioning
8. `uuid-split/08-it-bench-docs` — UUID integration tests, benchmarks and docs

Full feature description, v1 design contract, scope exclusions, and benchmark numbers: [apache/pinot#18140](https://github.com/apache/pinot/pull/18140).
