### PR TITLE
[UUID 7/8] UUID scalar UDFs and partitioning

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -461,7 +461,7 @@ public class StringFunctions {
    */
   @ScalarFunction
   public static String fromUUIDBytes(byte[] input) {
-    return UuidUtils.fromBytes(input).toString();
+    return UuidUtils.toString(input);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/array/ArrayLengthScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/array/ArrayLengthScalarFunction.java
@@ -59,6 +59,9 @@ public class ArrayLengthScalarFunction implements PinotScalarFunction {
       TYPE_FUNCTION_INFO_MAP.put(DataSchema.ColumnDataType.BYTES_ARRAY,
           new FunctionInfo(ArrayLengthScalarFunction.class.getMethod("arrayLength", byte[][].class),
               ArrayLengthScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(DataSchema.ColumnDataType.UUID_ARRAY,
+          new FunctionInfo(ArrayLengthScalarFunction.class.getMethod("arrayLength", byte[][].class),
+              ArrayLengthScalarFunction.class, false));
     } catch (NoSuchMethodException e) {
       throw new RuntimeException(e);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/array/ArraysOverlapScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/array/ArraysOverlapScalarFunction.java
@@ -70,6 +70,9 @@ public class ArraysOverlapScalarFunction implements PinotScalarFunction {
       TYPE_FUNCTION_INFO_MAP.put(DataSchema.ColumnDataType.BYTES_ARRAY,
           new FunctionInfo(ArraysOverlapScalarFunction.class.getMethod("arraysOverlap", byte[][].class, byte[][].class),
               ArraysOverlapScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(DataSchema.ColumnDataType.UUID_ARRAY,
+          new FunctionInfo(ArraysOverlapScalarFunction.class.getMethod("arraysOverlap", byte[][].class, byte[][].class),
+              ArraysOverlapScalarFunction.class, false));
     } catch (NoSuchMethodException e) {
       throw new RuntimeException(e);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/AbstractStringOrBytesUuidFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/AbstractStringOrBytesUuidFunction.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+
+
+/**
+ * Base class for UUID scalar functions that accept either a STRING or BYTES argument.
+ * Subclasses provide the two {@link FunctionInfo} constants and delegate the
+ * polymorphic dispatch here.
+ */
+abstract class AbstractStringOrBytesUuidFunction implements PinotScalarFunction {
+
+  /** {@link FunctionInfo} for the {@code String} overload. */
+  protected abstract FunctionInfo getStringFunctionInfo();
+
+  /** {@link FunctionInfo} for the {@code byte[]} overload. */
+  protected abstract FunctionInfo getBytesFunctionInfo();
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
+    if (argumentTypes.length != 1) {
+      return null;
+    }
+    switch (argumentTypes[0]) {
+      case STRING:
+        return getStringFunctionInfo();
+      case BYTES:
+        return getBytesFunctionInfo();
+      default:
+        return null;
+    }
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(int numArguments) {
+    return numArguments == 1 ? getStringFunctionInfo() : null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/IsUuidScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/IsUuidScalarFunction.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.UuidUtils;
+
+
+/**
+ * Polymorphic scalar function that validates string or bytes values as UUID inputs.
+ *
+ * <p>This implementation is stateless and thread-safe.
+ */
+@ScalarFunction(names = {"IS_UUID"})
+public class IsUuidScalarFunction extends AbstractStringOrBytesUuidFunction {
+  private static final FunctionInfo STRING_FUNCTION_INFO;
+  private static final FunctionInfo BYTES_FUNCTION_INFO;
+
+  static {
+    try {
+      STRING_FUNCTION_INFO =
+          new FunctionInfo(IsUuidScalarFunction.class.getMethod("isUuid", String.class), IsUuidScalarFunction.class,
+              true);
+      BYTES_FUNCTION_INFO =
+          new FunctionInfo(IsUuidScalarFunction.class.getMethod("isUuid", byte[].class), IsUuidScalarFunction.class,
+              true);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected FunctionInfo getStringFunctionInfo() {
+    return STRING_FUNCTION_INFO;
+  }
+
+  @Override
+  protected FunctionInfo getBytesFunctionInfo() {
+    return BYTES_FUNCTION_INFO;
+  }
+
+  @Override
+  public String getName() {
+    return "IS_UUID";
+  }
+
+  @Override
+  public Set<String> getNames() {
+    return Set.of("IS_UUID", "ISUUID");
+  }
+
+  @Nullable
+  @Override
+  public PinotSqlFunction toPinotSqlFunction() {
+    return new PinotSqlFunction("IS_UUID", ReturnTypes.BOOLEAN,
+        OperandTypes.or(OperandTypes.family(List.of(SqlTypeFamily.CHARACTER)),
+            OperandTypes.family(List.of(SqlTypeFamily.BINARY))));
+  }
+
+  public static boolean isUuid(String value) {
+    return UuidUtils.isUuid(value);
+  }
+
+  public static boolean isUuid(byte[] value) {
+    return UuidUtils.isUuid(value);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/ToUuidScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/ToUuidScalarFunction.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.UuidUtils;
+
+
+/**
+ * Polymorphic scalar function that converts string or bytes inputs into Pinot's logical UUID type.
+ *
+ * <p>This implementation is stateless and thread-safe.
+ */
+@ScalarFunction(names = {"TO_UUID"})
+public class ToUuidScalarFunction extends AbstractStringOrBytesUuidFunction {
+  private static final FunctionInfo STRING_FUNCTION_INFO;
+  private static final FunctionInfo BYTES_FUNCTION_INFO;
+
+  static {
+    try {
+      STRING_FUNCTION_INFO =
+          new FunctionInfo(ToUuidScalarFunction.class.getMethod("toUuid", String.class), ToUuidScalarFunction.class,
+              true);
+      BYTES_FUNCTION_INFO =
+          new FunctionInfo(ToUuidScalarFunction.class.getMethod("toUuid", byte[].class), ToUuidScalarFunction.class,
+              true);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected FunctionInfo getStringFunctionInfo() {
+    return STRING_FUNCTION_INFO;
+  }
+
+  @Override
+  protected FunctionInfo getBytesFunctionInfo() {
+    return BYTES_FUNCTION_INFO;
+  }
+
+  @Override
+  public String getName() {
+    return "TO_UUID";
+  }
+
+  @Override
+  public Set<String> getNames() {
+    return Set.of("TO_UUID", "TOUUID");
+  }
+
+  @Nullable
+  @Override
+  public PinotSqlFunction toPinotSqlFunction() {
+    return new PinotSqlFunction("TO_UUID", ReturnTypes.explicit(org.apache.calcite.sql.type.SqlTypeName.UUID),
+        OperandTypes.or(OperandTypes.family(List.of(SqlTypeFamily.CHARACTER)),
+            OperandTypes.family(List.of(SqlTypeFamily.BINARY))));
+  }
+
+  public static UUID toUuid(String value) {
+    return value != null ? UuidUtils.toUUID(value) : null;
+  }
+
+  public static UUID toUuid(byte[] value) {
+    return value != null ? UuidUtils.toUUID(value) : null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctions.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.UUID;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.UuidUtils;
+
+
+/**
+ * UUID conversion scalar functions.
+ *
+ * <p>These functions are stateless and thread-safe.
+ */
+public final class UuidConversionFunctions {
+  private UuidConversionFunctions() {
+  }
+
+  @ScalarFunction(names = {"UUID_TO_BYTES"}, nullableParameters = true)
+  public static byte[] uuidToBytes(UUID uuid) {
+    return uuid != null ? UuidUtils.toBytes(uuid) : null;
+  }
+
+  @ScalarFunction(names = {"BYTES_TO_UUID"}, nullableParameters = true)
+  public static UUID bytesToUuid(byte[] bytes) {
+    return bytes != null ? UuidUtils.toUUID(bytes) : null;
+  }
+
+  @ScalarFunction(names = {"UUID_TO_STRING"}, nullableParameters = true)
+  public static String uuidToString(UUID uuid) {
+    return uuid != null ? UuidUtils.toString(uuid) : null;
+  }
+
+  /**
+   * Generates a fresh random RFC 4122 version-4 UUID. Each invocation produces a new value, so this function
+   * is non-deterministic and is annotated with {@code isDeterministic = false} to prevent the broker's
+   * {@code CompileTimeFunctionsInvoker} from folding the call into a single literal that is reused for every row.
+   */
+  @ScalarFunction(names = {"UUID_V4"}, isDeterministic = false)
+  public static UUID uuidV4() {
+    return UuidUtils.randomV4();
+  }
+
+  /**
+   * Generates a fresh RFC 9562 version-7 (Unix-time-based) UUID. The leading 48 bits encode the current Unix
+   * time in milliseconds, making v7 UUIDs k-sortable and well-suited to time-ordered primary keys. Each
+   * invocation produces a new value, so this function is non-deterministic and is annotated with
+   * {@code isDeterministic = false} to prevent compile-time folding.
+   */
+  @ScalarFunction(names = {"UUID_V7"}, isDeterministic = false)
+  public static UUID uuidV7() {
+    return UuidUtils.randomV7();
+  }
+
+  /**
+   * Returns the 4-bit version field (0-15) of the given UUID. Common values: 1, 3, 4, 5, 6, 7, 8.
+   */
+  @ScalarFunction(names = {"UUID_VERSION"}, nullableParameters = true)
+  public static Integer uuidVersion(UUID uuid) {
+    return uuid != null ? UuidUtils.getVersion(uuid) : null;
+  }
+
+  /**
+   * Returns the embedded Unix-millisecond timestamp from a time-based UUID (version 1, 6, or 7). Throws
+   * for non-time-based versions.
+   */
+  @ScalarFunction(names = {"UUID_TIMESTAMP"}, nullableParameters = true)
+  public static Long uuidTimestamp(UUID uuid) {
+    return uuid != null ? UuidUtils.getTimestampMillis(uuid) : null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/partition/function/UuidPartitionFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/partition/function/UuidPartitionFunction.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.partition.function;
+
+import com.google.common.base.Preconditions;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionIdNormalizer;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.spi.utils.hash.MurmurHashFunctions;
+
+
+/// Partition function for Pinot's logical UUID type. Parses the canonical RFC 4122 UUID string into its
+/// 16-byte binary form, hashes those bytes via Murmur2, and runs the configured [PartitionIdNormalizer]
+/// (default [PartitionIdNormalizer#MASK]) to derive the partition id.
+///
+/// This matches what an external producer that hashes the 16-byte UUID via Murmur2 would compute (the
+/// most common convention for UUID-keyed messages in Kafka/Pulsar/Kinesis).
+///
+/// Hashing the binary form avoids two pitfalls of hashing the canonical UUID string directly: the dashes
+/// do not contribute entropy, and producers that emit raw UUID bytes on the wire would otherwise need a
+/// Pinot-only canonical-format step in their partitioning code.
+public class UuidPartitionFunction implements PartitionFunction {
+  private static final String NAME = "Uuid";
+  private static final PartitionIdNormalizer DEFAULT_NORMALIZER = PartitionIdNormalizer.MASK;
+  private final int _numPartitions;
+  private final PartitionIdNormalizer _normalizer;
+
+  public UuidPartitionFunction(int numPartitions, @Nullable Map<String, String> functionConfig) {
+    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, was: %s", numPartitions);
+    _numPartitions = numPartitions;
+    _normalizer = PartitionFunctionConfigs.normalizer(functionConfig, DEFAULT_NORMALIZER);
+  }
+
+  @Override
+  public int getPartition(String value) {
+    byte[] uuidBytes = UuidUtils.toBytes(value);
+    return _normalizer.getPartitionId(MurmurHashFunctions.murmurHash2(uuidBytes), _numPartitions);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getNumPartitions() {
+    return _numPartitions;
+  }
+
+  @Override
+  public PartitionIdNormalizer getPartitionIdNormalizer() {
+    return _normalizer;
+  }
+
+  // Keep it for backward-compatibility, use getName() instead
+  @Override
+  public String toString() {
+    return NAME;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -235,6 +236,15 @@ public class StringFunctionsTest {
         {"hello@world.com", "Hello@world.com"},
         {"one,two,three", "One,two,three"}
     };
+  }
+
+  @Test
+  public void testToUuidBytesAcceptsMixedCaseInput() {
+    String mixedCaseUuid = "550E8400-E29B-41D4-A716-446655440000";
+    byte[] uuidBytes = StringFunctions.toUUIDBytes(mixedCaseUuid);
+
+    assertNotNull(uuidBytes);
+    assertEquals(StringFunctions.fromUUIDBytes(uuidBytes), "550e8400-e29b-41d4-a716-446655440000");
   }
 
   @DataProvider(name = "levenshteinDistanceTestCases")

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctionsTest.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.UUID;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class UuidConversionFunctionsTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String MIXED_CASE_UUID_VALUE = "550E8400-E29B-41D4-A716-446655440000";
+
+  @DataProvider(name = "invalidUuidStrings")
+  public Object[][] invalidUuidStrings() {
+    return new Object[][]{
+        {"550e8400-e29b-41d4-a716-44665544000"},
+        {"550e8400-e29b-41d4-a716-4466554400000"},
+        {"550e8400-e29b-41d4-a716-44665544000g"},
+        {"550e8400e29b41d4a716446655440000"},
+        {""}
+    };
+  }
+
+  @DataProvider(name = "invalidUuidBytes")
+  public Object[][] invalidUuidBytes() {
+    return new Object[][]{
+        {new byte[15]},
+        {new byte[17]}
+    };
+  }
+
+  @Test
+  public void testToUuidFromStringNormalizesToLowerCase() {
+    assertEquals(ToUuidScalarFunction.toUuid(MIXED_CASE_UUID_VALUE), UUID.fromString(UUID_VALUE));
+  }
+
+  @Test
+  public void testToUuidFromBytes() {
+    byte[] bytes = UuidUtils.toBytes(UUID_VALUE);
+
+    assertEquals(ToUuidScalarFunction.toUuid(bytes), UUID.fromString(UUID_VALUE));
+    assertEquals(UuidConversionFunctions.bytesToUuid(bytes), UUID.fromString(UUID_VALUE));
+  }
+
+  @Test
+  public void testUuidToBytesAndString() {
+    UUID uuid = UUID.fromString(UUID_VALUE);
+
+    assertEquals(UuidConversionFunctions.uuidToBytes(uuid), UuidUtils.toBytes(UUID_VALUE));
+    assertEquals(UuidConversionFunctions.uuidToString(uuid), UUID_VALUE);
+  }
+
+  @Test
+  public void testIsUuid() {
+    assertTrue(IsUuidScalarFunction.isUuid(UUID_VALUE));
+    assertTrue(IsUuidScalarFunction.isUuid(UuidUtils.toBytes(UUID_VALUE)));
+    assertFalse(IsUuidScalarFunction.isUuid("not-a-uuid"));
+    assertFalse(IsUuidScalarFunction.isUuid(new byte[15]));
+  }
+
+  @Test(dataProvider = "invalidUuidStrings")
+  public void testToUuidRejectsInvalidString(String invalidUuid) {
+    Assert.expectThrows(IllegalArgumentException.class, () -> ToUuidScalarFunction.toUuid(invalidUuid));
+    assertFalse(IsUuidScalarFunction.isUuid(invalidUuid));
+  }
+
+  @Test(dataProvider = "invalidUuidBytes")
+  public void testBytesToUuidRejectsInvalidBytes(byte[] invalidBytes) {
+    Assert.expectThrows(IllegalArgumentException.class, () -> ToUuidScalarFunction.toUuid(invalidBytes));
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidConversionFunctions.bytesToUuid(invalidBytes));
+    assertFalse(IsUuidScalarFunction.isUuid(invalidBytes));
+  }
+
+  @Test
+  public void testNullInputs() {
+    assertNull(ToUuidScalarFunction.toUuid((String) null));
+    assertNull(ToUuidScalarFunction.toUuid((byte[]) null));
+    assertNull(UuidConversionFunctions.uuidToBytes(null));
+    assertNull(UuidConversionFunctions.bytesToUuid(null));
+    assertNull(UuidConversionFunctions.uuidToString(null));
+    assertNull(UuidConversionFunctions.uuidVersion(null));
+    assertNull(UuidConversionFunctions.uuidTimestamp(null));
+    assertFalse(IsUuidScalarFunction.isUuid((String) null));
+    assertFalse(IsUuidScalarFunction.isUuid((byte[]) null));
+  }
+
+  @Test
+  public void testUuidV4ProducesValidVersion4Uuid() {
+    UUID uuid = UuidConversionFunctions.uuidV4();
+    assertEquals(uuid.version(), 4, "uuidV4 must produce version 4");
+    assertEquals(UuidConversionFunctions.uuidVersion(uuid).intValue(), 4);
+
+    // Two successive calls should not return the same value (probability of collision is ~0).
+    UUID other = UuidConversionFunctions.uuidV4();
+    assertFalse(uuid.equals(other), "Successive uuidV4 calls collided");
+  }
+
+  @Test
+  public void testUuidV7EncodesCurrentUnixMillisAndIsKSortable() {
+    long before = System.currentTimeMillis();
+    UUID first = UuidConversionFunctions.uuidV7();
+    UUID second = UuidConversionFunctions.uuidV7();
+    long after = System.currentTimeMillis();
+
+    assertEquals(first.version(), 7, "uuidV7 must produce version 7");
+    assertEquals(UuidConversionFunctions.uuidVersion(first).intValue(), 7);
+
+    long firstTs = UuidConversionFunctions.uuidTimestamp(first);
+    long secondTs = UuidConversionFunctions.uuidTimestamp(second);
+
+    assertTrue(firstTs >= before && firstTs <= after,
+        "uuidV7 timestamp " + firstTs + " not within [" + before + ", " + after + "]");
+    assertTrue(secondTs >= firstTs, "uuidV7 timestamps must be monotonically non-decreasing across calls");
+
+    // Variant must be RFC 4122 (top two bits of LSB = 10).
+    assertEquals(first.variant(), 2, "uuidV7 must use RFC 4122 variant");
+  }
+
+  @Test
+  public void testUuidVersionForKnownVersions() {
+    // Version 4 — random.
+    assertEquals(UuidConversionFunctions.uuidVersion(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+        .intValue(), 4);
+    // Version 1 — Gregorian time-based.
+    assertEquals(UuidConversionFunctions.uuidVersion(UUID.fromString("c232ab00-9414-11ec-b3c8-9e6bdeced846"))
+        .intValue(), 1);
+    // Version 7 — Unix-time-based.
+    assertEquals(UuidConversionFunctions.uuidVersion(UUID.fromString("017f22e2-79b0-7cc3-98c4-dc0c0c07398f"))
+        .intValue(), 7);
+  }
+
+  @Test
+  public void testUuidTimestampRejectsNonTimeBasedVersions() {
+    UUID v4 = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidConversionFunctions.uuidTimestamp(v4));
+  }
+
+  @Test
+  public void testUuidTimestampDecodesV7FixedSample() {
+    // Construct a v7 UUID with known unix ms = 0x017F22E279B0L = 1645557742000 (2022-02-22T19:22:22Z).
+    long unixMs = 0x017F22E279B0L;
+    long msb = (unixMs << 16) | 0x7000L | 0x0CC3L;
+    long lsb = 0x8000000000000000L | 0x18C4DC0C0C07398FL;
+    UUID v7 = new UUID(msb, lsb);
+    assertEquals(UuidConversionFunctions.uuidTimestamp(v7).longValue(), unixMs);
+    assertEquals(UuidConversionFunctions.uuidVersion(v7).intValue(), 7);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/partition/function/PartitionFunctionTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/partition/function/PartitionFunctionTest.java
@@ -778,6 +778,62 @@ public class PartitionFunctionTest {
     testPartitionFunction(byteArrayPartitionFunction, expectedPartitions);
   }
 
+  /**
+   * Unit test for {@link UuidPartitionFunction}.
+   * <ul>
+   *   <li> Verifies factory registration. </li>
+   *   <li> Verifies partition values are deterministic and in [0, numPartitions). </li>
+   *   <li> Verifies the function hashes the 16-byte UUID form (canonical-string format does not affect the hash). </li>
+   *   <li> Verifies an invalid UUID string throws. </li>
+   * </ul>
+   */
+  @Test
+  public void testUuidPartitioner() {
+    int numPartitions = 64;
+
+    // Factory registration (case-insensitive name lookup) should produce a UuidPartitionFunction.
+    PartitionFunction viaFactory = PartitionFunctionFactory.getPartitionFunction("uUiD", numPartitions, null);
+    assertEquals(viaFactory.getName(), "Uuid");
+    assertEquals(viaFactory.getNumPartitions(), numPartitions);
+    assertTrue(viaFactory instanceof UuidPartitionFunction);
+
+    UuidPartitionFunction direct = new UuidPartitionFunction(numPartitions, null);
+    testBasicProperties(direct, "Uuid", numPartitions);
+
+    // Determinism + range.
+    String[] uuids = new String[]{
+        "00000000-0000-0000-0000-000000000000",
+        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "12345678-1234-1234-1234-1234567890ab",
+        "9c5e1f24-0b8e-4c9d-87f1-0aa64a3b9d12",
+        "550e8400-e29b-41d4-a716-446655440000"
+    };
+    for (String uuid : uuids) {
+      int partition = direct.getPartition(uuid);
+      assertTrue(partition >= 0 && partition < numPartitions, "partition " + partition + " out of range");
+      assertEquals(direct.getPartition(uuid), partition, "non-deterministic partition for " + uuid);
+
+      // Hash matches the documented contract: murmurHash2 of the 16-byte canonical form, masked, modulo numPartitions.
+      byte[] uuidBytes = org.apache.pinot.spi.utils.UuidUtils.toBytes(uuid);
+      int expected = (MurmurHashFunctions.murmurHash2(uuidBytes) & Integer.MAX_VALUE) % numPartitions;
+      assertEquals(partition, expected);
+    }
+
+    // Different UUIDs should not all collapse to the same partition (basic spread sanity check).
+    int firstPartition = direct.getPartition(uuids[0]);
+    boolean spread = false;
+    for (int i = 1; i < uuids.length; i++) {
+      if (direct.getPartition(uuids[i]) != firstPartition) {
+        spread = true;
+        break;
+      }
+    }
+    assertTrue(spread, "UuidPartitionFunction collapsed all sample UUIDs to the same partition");
+
+    // Invalid UUID must surface as an exception (not a silent zero partition).
+    expectThrows(IllegalArgumentException.class, () -> direct.getPartition("not-a-uuid"));
+  }
+
   private void testPartitionInExpectedRange(PartitionFunction partitionFunction, Object value, int numPartitions) {
     int partition = partitionFunction.getPartition(value.toString());
     assertTrue(partition >= 0 && partition < numPartitions);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/PartitionerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/PartitionerFactory.java
@@ -20,6 +20,9 @@ package org.apache.pinot.core.segment.processing.partitioner;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 
 
 /**
@@ -53,6 +56,17 @@ public final class PartitionerFactory {
    * Construct a Partitioner using the PartitioningConfig
    */
   public static Partitioner getPartitioner(PartitionerConfig config) {
+    return getPartitioner(config, null);
+  }
+
+  /**
+   * Construct a Partitioner using the PartitioningConfig. When {@code schema} is non-null and the partitioner
+   * is column-aware (e.g. {@link PartitionerType#TABLE_PARTITION_CONFIG}), the column's logical
+   * {@link FieldSpec.DataType} is threaded through so values are rendered via
+   * {@link FieldSpec.DataType#toString(Object)} (canonical UUID strings for UUID columns) instead of the bare
+   * hex from {@link FieldSpec#getStringValue}.
+   */
+  public static Partitioner getPartitioner(PartitionerConfig config, @Nullable Schema schema) {
 
     Partitioner partitioner = null;
     switch (config.getPartitionerType()) {
@@ -79,7 +93,14 @@ public final class PartitionerFactory {
             "Must provide columnName for TABLE_PARTITION_CONFIG Partitioner");
         Preconditions.checkState(config.getColumnPartitionConfig() != null,
             "Must provide columnPartitionConfig for TABLE_PARTITION_CONFIG Partitioner");
-        partitioner = new TableConfigPartitioner(config.getColumnName(), config.getColumnPartitionConfig());
+        FieldSpec.DataType dataType = null;
+        if (schema != null) {
+          FieldSpec fieldSpec = schema.getFieldSpecFor(config.getColumnName());
+          if (fieldSpec != null) {
+            dataType = fieldSpec.getDataType();
+          }
+        }
+        partitioner = new TableConfigPartitioner(config.getColumnName(), config.getColumnPartitionConfig(), dataType);
         break;
       default:
         break;
@@ -93,10 +114,17 @@ public final class PartitionerFactory {
    * @return Array of partitioners
    */
   public static Partitioner[] getPartitioners(List<PartitionerConfig> partitionerConfigs) {
+    return getPartitioners(partitionerConfigs, null);
+  }
+
+  /**
+   * Create partitioner array from configuration, optionally type-aware via the provided {@link Schema}.
+   */
+  public static Partitioner[] getPartitioners(List<PartitionerConfig> partitionerConfigs, @Nullable Schema schema) {
     int numPartitioners = partitionerConfigs.size();
     Partitioner[] partitioners = new Partitioner[numPartitioners];
     for (int i = 0; i < numPartitioners; i++) {
-      partitioners[i] = PartitionerFactory.getPartitioner(partitionerConfigs.get(i));
+      partitioners[i] = PartitionerFactory.getPartitioner(partitionerConfigs.get(i), schema);
     }
     return partitioners;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.core.segment.processing.partitioner;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -31,15 +33,27 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public class TableConfigPartitioner implements Partitioner {
   private final String _column;
   private final PartitionFunction _partitionFunction;
+  /// Non-null when the column's logical type is known. Used to render values via
+  /// {@link DataType#toString(Object)} so UUID columns produce the canonical RFC 4122 form
+  /// (matching MutableSegmentImpl's runtime partition path and the {@code Uuid} partition function's
+  /// expectation) instead of the bare-hex string that {@link FieldSpec#getStringValue} would emit.
+  @Nullable
+  private final DataType _dataType;
 
   public TableConfigPartitioner(String columnName, ColumnPartitionConfig columnPartitionConfig) {
+    this(columnName, columnPartitionConfig, null);
+  }
+
+  public TableConfigPartitioner(String columnName, ColumnPartitionConfig columnPartitionConfig,
+      @Nullable DataType dataType) {
     _column = columnName;
     _partitionFunction = PartitionFunctionFactory.getPartitionFunction(columnPartitionConfig);
+    _dataType = dataType;
   }
 
   @Override
   public String getPartition(GenericRow genericRow) {
-    return String.valueOf(_partitionFunction.getPartition(FieldSpec.getStringValue(genericRow.getValue(_column))));
+    return String.valueOf(_partitionFunction.getPartition(toPartitionString(genericRow.getValue(_column))));
   }
 
   @Override
@@ -53,6 +67,10 @@ public class TableConfigPartitioner implements Partitioner {
       throw new IllegalArgumentException(
           "TableConfigPartitioner expects exactly 1 column value, got " + columnValues.length);
     }
-    return String.valueOf(_partitionFunction.getPartition(FieldSpec.getStringValue(columnValues[0])));
+    return String.valueOf(_partitionFunction.getPartition(toPartitionString(columnValues[0])));
+  }
+
+  private String toPartitionString(Object value) {
+    return _dataType != null ? _dataType.toString(value) : FieldSpec.getStringValue(value);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/BytesToUuidUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/BytesToUuidUdf.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class BytesToUuidUdf extends Udf.FromAnnotatedMethod {
+  public BytesToUuidUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("bytesToUuid", byte[].class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a 16-byte BYTES value into a canonical lowercase UUID string rendered as Pinot UUID.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/IsUuidUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/IsUuidUdf.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.scalar.uuid.IsUuidScalarFunction;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class IsUuidUdf extends Udf {
+  private static final IsUuidScalarFunction SCALAR_FUNCTION = new IsUuidScalarFunction();
+
+  @Override
+  public String getMainName() {
+    return SCALAR_FUNCTION.getName();
+  }
+
+  @Override
+  public Set<String> getAllNames() {
+    return SCALAR_FUNCTION.getNames();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns true when the input is a valid RFC 4122 UUID string or a 16-byte BYTES value.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+
+  @Override
+  public PinotScalarFunction getScalarFunction() {
+    return SCALAR_FUNCTION;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/ToUuidUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/ToUuidUdf.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.scalar.uuid.ToUuidScalarFunction;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class ToUuidUdf extends Udf {
+  private static final ToUuidScalarFunction SCALAR_FUNCTION = new ToUuidScalarFunction();
+
+  @Override
+  public String getMainName() {
+    return SCALAR_FUNCTION.getName();
+  }
+
+  @Override
+  public Set<String> getAllNames() {
+    return SCALAR_FUNCTION.getNames();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a canonical UUID string or a 16-byte BYTES value into Pinot's logical UUID type.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+
+  @Override
+  public PinotScalarFunction getScalarFunction() {
+    return SCALAR_FUNCTION;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidTimestampUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidTimestampUdf.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidTimestampUdf extends Udf.FromAnnotatedMethod {
+  public UuidTimestampUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidTimestamp", java.util.UUID.class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the embedded Unix-millisecond timestamp from a time-based UUID (version 1, 6, or 7). "
+        + "Throws for non-time-based versions.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToBytesUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToBytesUdf.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidToBytesUdf extends Udf.FromAnnotatedMethod {
+  public UuidToBytesUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidToBytes", java.util.UUID.class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a UUID value to its canonical 16-byte representation.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToStringUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToStringUdf.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidToStringUdf extends Udf.FromAnnotatedMethod {
+  public UuidToStringUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidToString", java.util.UUID.class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a UUID value to its canonical lowercase RFC 4122 string representation.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidV4Udf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidV4Udf.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidV4Udf extends Udf.FromAnnotatedMethod {
+  public UuidV4Udf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidV4"));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Generates a fresh random RFC 4122 version-4 UUID. Each invocation produces a new value.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidV7Udf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidV7Udf.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidV7Udf extends Udf.FromAnnotatedMethod {
+  public UuidV7Udf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidV7"));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Generates a fresh RFC 9562 version-7 (Unix-time-based) UUID. The leading 48 bits encode the current "
+        + "Unix time in milliseconds, making v7 UUIDs k-sortable and well-suited to time-ordered primary keys.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidVersionUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidVersionUdf.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidVersionUdf extends Udf.FromAnnotatedMethod {
+  public UuidVersionUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidVersion", java.util.UUID.class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the 4-bit version field (0-15) of the given UUID. Common values: 1, 3, 4, 5, 6, 7, 8.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Map.of();
+  }
+}


### PR DESCRIPTION
## What
UUID scalar functions and partitioning.

## Changes
- scalar UDFs: `isUuid`, `toUuid`, byte/string conversions, `uuid_v4`, `uuid_v7`, `uuidVersion`, `uuidTimestamp` (generators marked non-deterministic)
- `UuidPartitionFunction` + `PartitionerFactory` / `TableConfigPartitioner` wiring

## Enables
UUID generation, accessors, conversions, and UUID-based segment/stream partitioning.

## Depends on
PR 1.

## Why this PR exists
This is **part 7 of 8** splitting [apache/pinot#18140](https://github.com/apache/pinot/pull/18140) (first-class logical `UUID` type) into reviewable, layered PRs, as requested on that PR.

The split is enabled by the v1 design: `DataType.UUID` has **stored type `BYTES`**, so most code paths handle it automatically; each PR adds explicit UUID semantics to one subsystem.

This PR is **stacked on `06-mse-planner-runtime`** (its base branch), so the diff shown here is **only this layer**.

### Full stack (base → top)
1. `uuid-split/01-spi-foundation` — Add logical UUID type foundation (pinot-spi)
2. `uuid-split/02-ingest-storage` — UUID ingest and segment storage
3. `uuid-split/03-result-rendering` — UUID result rendering (DataSchema, Arrow/JSON encoders)
4. `uuid-split/04-sse-predicates-cast` — UUID server-side predicates, CAST and transforms
5. `uuid-split/05-agg-groupby-distinct` — UUID aggregation, group-by and distinct
6. `uuid-split/06-mse-planner-runtime` — UUID multi-stage engine (planner + runtime)
7. `uuid-split/07-udfs-partitioning` — UUID scalar UDFs and partitioning
8. `uuid-split/08-it-bench-docs` — UUID integration tests, benchmarks and docs

Full feature description, v1 design contract, scope exclusions, and benchmark numbers: [apache/pinot#18140](https://github.com/apache/pinot/pull/18140).
