### PR TITLE
[UUID 8/8] UUID integration tests, benchmarks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,5 +193,55 @@ Check out [Pinot documentation](https://docs.pinot.apache.org/) for a complete d
 - [Pinot Architecture](https://docs.pinot.apache.org/basics/architecture)
 - [Pinot Query Language](https://docs.pinot.apache.org/users/user-guide-query/pinot-query-language)
 
+### UUID Logical Type
+
+Pinot supports a logical `UUID` type for both single- and multi-value columns. In v1, Pinot stores `UUID` values
+using the existing 16-byte `BYTES` representation, while schema definitions and query results use canonical
+lowercase RFC 4122 strings.
+
+Schema example:
+```json
+{
+  "schemaName": "events",
+  "dimensionFieldSpecs": [
+    {
+      "name": "eventId",
+      "dataType": "UUID"
+    }
+  ]
+}
+```
+
+Query example:
+```sql
+SELECT eventId
+FROM events
+WHERE eventId = CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID)
+```
+
+UUID conversion helpers:
+```sql
+SELECT
+  TO_UUID('550E8400-E29B-41D4-A716-446655440000'),
+  UUID_TO_STRING(eventId),
+  UUID_TO_BYTES(eventId),
+  BYTES_TO_UUID(eventIdBytes),
+  IS_UUID(eventIdBytes)
+FROM events
+```
+
+Behavior notes:
+- Pinot accepts canonical RFC 4122 UUID strings in either upper or lower case on ingest and in functions/casts.
+- Pinot always renders `UUID` results as canonical lowercase strings.
+- `CAST(... AS UUID)` accepts canonical strings and 16-byte `BYTES` values.
+
+Migration notes:
+- Existing `BYTES` columns keep returning hex strings. Pinot only renders canonical UUID strings for columns declared as `UUID`.
+- Pinot does not support changing the data type of an existing column in place. To adopt `UUID` for existing
+  `STRING` or `BYTES` UUID-shaped data, create a new `UUID` column or a new table/schema and reingest/backfill the
+  data into it.
+- The `UUID` type itself does not require a segment or wire format bump in v1, but migration still requires rebuild or
+  reingest because schema type mutation is unsupported.
+
 ## License
 Apache Pinot is under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -787,6 +787,7 @@ public abstract class ClusterTest extends ControllerTest {
         case BIG_DECIMAL_ARRAY:
         case TIMESTAMP_ARRAY:
         case STRING_ARRAY:
+        case UUID_ARRAY:
         case BYTES_ARRAY:
           array[k] = jsonValue.get(k).textValue();
           break;
@@ -821,6 +822,7 @@ public abstract class ClusterTest extends ControllerTest {
       case BIG_DECIMAL:
       case TIMESTAMP:
       case STRING:
+      case UUID:
       case BYTES:
       case JSON:
         object = jsonValue.textValue();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
@@ -144,7 +144,8 @@ public abstract class CustomDataQueryClusterIntegrationTest extends BaseClusterI
     if (isRealtimeTable()) {
       // In suite mode multiple realtime tests use different topics, so make sure
       // this class-specific topic exists before the controller validates stream metadata.
-      _sharedClusterTestSuite.createKafkaTopic(getKafkaTopic());
+      // Pass getNumKafkaPartitions() explicitly so subclass overrides are respected.
+      _sharedClusterTestSuite.createKafkaTopic(getKafkaTopic(), getNumKafkaPartitions());
       waitForKafkaTopicMetadataReadyForConsumer(getKafkaTopic(), getNumKafkaPartitions());
 
       // create realtime table

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeRealtimeTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+
+public class UuidTypeRealtimeTest extends UuidTypeTest {
+  private static final String REALTIME_TABLE_NAME = "UuidTypeRealtimeTest";
+
+  @Override
+  public String getTableName() {
+    return REALTIME_TABLE_NAME;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeTest.java
@@ -1,0 +1,548 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class UuidTypeTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String DEFAULT_TABLE_NAME = "UuidTypeTest";
+  private static final String ID_COLUMN = "id";
+  private static final String UUID_FROM_STRING_COLUMN = "uuidFromString";
+  private static final String UUID_FROM_BYTES_COLUMN = "uuidFromBytes";
+  private static final String UUID_AS_BYTES_COLUMN = "uuidAsBytes";
+  private static final String UUID_ARRAY_FROM_STRING_COLUMN = "uuidArrayFromString";
+  private static final String UUID_ARRAY_FROM_BYTES_COLUMN = "uuidArrayFromBytes";
+  private static final String TIME_COLUMN = "ts";
+  private static final List<String> UUID_INPUT_VALUES = List.of(
+      "550E8400-E29B-41D4-A716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-E29B-41D4-A716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550E8400-E29B-41D4-A716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440003");
+  private static final List<String> UUID_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440003");
+  private static final List<String> DISTINCT_UUID_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550e8400-e29b-41d4-a716-446655440003");
+  private static final List<Integer> SORTED_UUID_IDS = List.of(0, 2, 1, 4, 3, 5);
+  private static final long BASE_TIMESTAMP_MILLIS = 1_700_000_000_000L;
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public String getTimeColumnName() {
+    return TIME_COLUMN;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return UUID_VALUES.size();
+  }
+
+  @Override
+  public int getNumAvroFiles() {
+    return 1;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return 2;
+  }
+
+  @Override
+  protected List<String> getInvertedIndexColumns() {
+    return List.of(UUID_FROM_STRING_COLUMN);
+  }
+
+  @Override
+  protected List<String> getNoDictionaryColumns() {
+    return List.of(UUID_FROM_BYTES_COLUMN, UUID_AS_BYTES_COLUMN, UUID_ARRAY_FROM_BYTES_COLUMN);
+  }
+
+  @Override
+  protected List<String> getBloomFilterColumns() {
+    return List.of(UUID_FROM_STRING_COLUMN, UUID_FROM_BYTES_COLUMN, UUID_AS_BYTES_COLUMN);
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(ID_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(UUID_FROM_STRING_COLUMN, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(UUID_FROM_BYTES_COLUMN, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(UUID_AS_BYTES_COLUMN, FieldSpec.DataType.BYTES)
+        .addMultiValueDimension(UUID_ARRAY_FROM_STRING_COLUMN, FieldSpec.DataType.UUID)
+        .addMultiValueDimension(UUID_ARRAY_FROM_BYTES_COLUMN, FieldSpec.DataType.UUID)
+        .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("uuidRecord", null, null, false);
+    org.apache.avro.Schema uuidStringArraySchema = org.apache.avro.Schema.createArray(create(Type.STRING));
+    org.apache.avro.Schema uuidBytesArraySchema = org.apache.avro.Schema.createArray(create(Type.BYTES));
+    avroSchema.setFields(List.of(
+        new Field(ID_COLUMN, create(Type.INT), null, null),
+        new Field(UUID_FROM_STRING_COLUMN, create(Type.STRING), null, null),
+        new Field(UUID_FROM_BYTES_COLUMN, create(Type.BYTES), null, null),
+        new Field(UUID_AS_BYTES_COLUMN, create(Type.BYTES), null, null),
+        new Field(UUID_ARRAY_FROM_STRING_COLUMN, uuidStringArraySchema, null, null),
+        new Field(UUID_ARRAY_FROM_BYTES_COLUMN, uuidBytesArraySchema, null, null),
+        new Field(TIME_COLUMN, create(Type.LONG), null, null)));
+
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < UUID_VALUES.size(); i++) {
+        String uuidInputValue = UUID_INPUT_VALUES.get(i);
+        byte[] uuidBytes = UuidUtils.toBytes(uuidInputValue);
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(ID_COLUMN, i);
+        record.put(UUID_FROM_STRING_COLUMN, uuidInputValue);
+        record.put(UUID_FROM_BYTES_COLUMN, ByteBuffer.wrap(uuidBytes));
+        record.put(UUID_AS_BYTES_COLUMN, ByteBuffer.wrap(uuidBytes));
+        record.put(UUID_ARRAY_FROM_STRING_COLUMN, uuidStringArray(i, uuidStringArraySchema));
+        record.put(UUID_ARRAY_FROM_BYTES_COLUMN, uuidBytesArray(i, uuidBytesArraySchema));
+        record.put(TIME_COLUMN, BASE_TIMESTAMP_MILLIS + i);
+        writers.get(0).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testSelectAndPredicateQueries(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s, %s, %s FROM %s ORDER BY %s", ID_COLUMN, UUID_FROM_STRING_COLUMN, UUID_FROM_BYTES_COLUMN,
+        UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN));
+
+    assertEquals(rows.size(), UUID_VALUES.size());
+    for (int i = 0; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asInt(), i);
+      assertEquals(rows.get(i).get(1).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(2).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(3).asText(), uuidHex(UUID_VALUES.get(i)));
+    }
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s = CAST('%s' AS UUID) ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, UUID_INPUT_VALUES.get(1).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 1, 4);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s IN (CAST('%s' AS UUID), CAST('%s' AS UUID)) ORDER BY %s", ID_COLUMN,
+        getTableName(), UUID_FROM_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(0).toUpperCase(), DISTINCT_UUID_VALUES.get(2),
+        ID_COLUMN));
+    assertIdRows(rows, 0, 2, 3);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s = TO_UUID('%s') ORDER BY %s", ID_COLUMN, getTableName(), UUID_FROM_STRING_COLUMN,
+        DISTINCT_UUID_VALUES.get(3).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 5);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s = UUID_TO_BYTES(CAST('%s' AS UUID)) ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_AS_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(1), ID_COLUMN));
+    assertIdRows(rows, 1, 4);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE CAST(%s AS UUID) = TO_UUID('%s') ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_AS_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(2).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 3);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s NOT IN (CAST('%s' AS UUID), CAST('%s' AS UUID)) ORDER BY %s", ID_COLUMN,
+        getTableName(), UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(0), DISTINCT_UUID_VALUES.get(3), ID_COLUMN));
+    assertIdRows(rows, 1, 3, 4);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testUuidArrayProjection(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s, %s, arrayLength(%s), arrayLength(%s) FROM %s ORDER BY %s", ID_COLUMN,
+        UUID_ARRAY_FROM_STRING_COLUMN, UUID_ARRAY_FROM_BYTES_COLUMN, UUID_ARRAY_FROM_STRING_COLUMN,
+        UUID_ARRAY_FROM_BYTES_COLUMN, getTableName(), ID_COLUMN));
+
+    assertEquals(rows.size(), UUID_VALUES.size());
+    for (int i = 0; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asInt(), i);
+      assertUuidArray(rows.get(i).get(1), i);
+      assertUuidArray(rows.get(i).get(2), i);
+      assertEquals(rows.get(i).get(3).asInt(), 2);
+      assertEquals(rows.get(i).get(4).asInt(), 2);
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testUuidFunctionsAndCaseQueries(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT UUID_TO_STRING(TO_UUID(UUID_TO_STRING(%s))), UUID_TO_STRING(TO_UUID(%s)), "
+            + "UUID_TO_STRING(BYTES_TO_UUID(%s)), UUID_TO_BYTES(%s), "
+            + "IS_UUID(UUID_TO_STRING(%s)), IS_UUID(%s), IS_UUID('not-a-uuid') "
+            + "FROM %s ORDER BY %s", UUID_FROM_STRING_COLUMN, UUID_AS_BYTES_COLUMN, UUID_FROM_BYTES_COLUMN,
+        UUID_FROM_BYTES_COLUMN, UUID_FROM_STRING_COLUMN, UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN));
+
+    assertEquals(rows.size(), UUID_VALUES.size());
+    for (int i = 0; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(1).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(2).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(3).asText(), uuidHex(UUID_VALUES.get(i)));
+      assertEquals(rows.get(i).get(4).asBoolean(), true);
+      assertEquals(rows.get(i).get(5).asBoolean(), true);
+      assertEquals(rows.get(i).get(6).asBoolean(), false);
+    }
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT CAST('%s' AS UUID) FROM %s ORDER BY %s LIMIT 1", DISTINCT_UUID_VALUES.get(0).toUpperCase(),
+        getTableName(), ID_COLUMN));
+    assertEquals(rows.size(), 1);
+    assertEquals(rows.get(0).get(0).asText(), DISTINCT_UUID_VALUES.get(0));
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT CASE WHEN %s < 2 THEN CAST('%s' AS UUID) ELSE BYTES_TO_UUID(%s) END "
+            + "FROM %s ORDER BY %s", ID_COLUMN, DISTINCT_UUID_VALUES.get(3).toUpperCase(), UUID_AS_BYTES_COLUMN,
+        getTableName(), ID_COLUMN));
+    assertEquals(rows.size(), UUID_VALUES.size());
+    assertEquals(rows.get(0).get(0).asText(), DISTINCT_UUID_VALUES.get(3));
+    assertEquals(rows.get(1).get(0).asText(), DISTINCT_UUID_VALUES.get(3));
+    for (int i = 2; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), UUID_VALUES.get(i));
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testGroupByDistinctOrderByAndParity(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, COUNT(*) FROM %s GROUP BY %s ORDER BY %s", UUID_FROM_STRING_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, UUID_FROM_STRING_COLUMN));
+    assertGroupedCounts(rows);
+
+    JsonNode rawRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, COUNT(*) FROM %s GROUP BY %s ORDER BY %s", UUID_FROM_BYTES_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, UUID_FROM_BYTES_COLUMN));
+    assertEquals(rawRows, rows);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT DISTINCT BYTES_TO_UUID(%s) FROM %s ORDER BY BYTES_TO_UUID(%s)", UUID_AS_BYTES_COLUMN, getTableName(),
+        UUID_AS_BYTES_COLUMN));
+    assertDistinctRows(rows);
+
+    JsonNode dictRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s FROM %s ORDER BY %s, %s", UUID_FROM_STRING_COLUMN, ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, ID_COLUMN));
+    JsonNode rawOrderRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s FROM %s ORDER BY %s, %s", UUID_FROM_BYTES_COLUMN, ID_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, ID_COLUMN));
+    assertEquals(rawOrderRows, dictRows);
+
+    for (int i = 0; i < SORTED_UUID_IDS.size(); i++) {
+      int expectedId = SORTED_UUID_IDS.get(i);
+      assertEquals(dictRows.get(i).get(0).asText(), UUID_VALUES.get(expectedId));
+      assertEquals(dictRows.get(i).get(1).asInt(), expectedId);
+    }
+  }
+
+  /**
+   * Tests range predicates on UUID columns (both dictionary-backed and no-dictionary).
+   *
+   * <p>UUID byte order determines sort order: the last segment of each test UUID differs only in the final byte
+   * (00–03), so the four distinct values have a well-defined byte-ordered range.
+   *
+   * <p>Only the single-stage engine is tested here; MSQE range pushdown for UUID columns is verified separately
+   * through the SSE/MSE parity checks in {@link #testSseMseParity}.
+   */
+  @Test
+  public void testRangePredicates()
+      throws Exception {
+    // uuidFromString is dictionary-backed; uuidFromBytes is no-dictionary (raw bytes)
+    // Sorted distinct values: 440000 < 440001 < 440002 < 440003
+
+    // GT on dictionary-backed UUID column: > 440001 → values 440002 (id=3), 440003 (id=5)
+    JsonNode rows = postRows(false, String.format(
+        "SELECT %s FROM %s WHERE %s > '%s' ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(1), ID_COLUMN));
+    assertIdRows(rows, 3, 5);
+
+    // LT on dictionary-backed UUID column: < 440002 → values 440000 (ids=0,2), 440001 (ids=1,4)
+    rows = postRows(false, String.format(
+        "SELECT %s FROM %s WHERE %s < '%s' ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(2), ID_COLUMN));
+    assertIdRows(rows, 0, 1, 2, 4);
+
+    // BETWEEN on no-dictionary UUID column: 440001–440002 inclusive → ids 1, 3, 4
+    rows = postRows(false, String.format(
+        "SELECT %s FROM %s WHERE %s BETWEEN '%s' AND '%s' ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(1), DISTINCT_UUID_VALUES.get(2), ID_COLUMN));
+    assertIdRows(rows, 1, 3, 4);
+
+    // GTE on no-dictionary UUID column: >= 440002 → values 440002 (id=3), 440003 (id=5)
+    rows = postRows(false, String.format(
+        "SELECT %s FROM %s WHERE %s >= '%s' ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(2), ID_COLUMN));
+    assertIdRows(rows, 3, 5);
+
+    // LTE on no-dictionary UUID column: <= 440001 → values 440000 (ids=0,2), 440001 (ids=1,4)
+    rows = postRows(false, String.format(
+        "SELECT %s FROM %s WHERE %s <= '%s' ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(1), ID_COLUMN));
+    assertIdRows(rows, 0, 1, 2, 4);
+
+    // Mixed-case UUID bounds are normalized: upper-case variant of 440001
+    rows = postRows(false, String.format(
+        "SELECT %s FROM %s WHERE %s > '%s' ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(1).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 3, 5);
+  }
+
+  @Test
+  public void testSseMseParity()
+      throws Exception {
+    List<String> queries = List.of(
+        String.format("SELECT %s, UUID_TO_STRING(BYTES_TO_UUID(%s)) AS uuidText FROM %s ORDER BY %s",
+            UUID_FROM_STRING_COLUMN, UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN),
+        String.format("SELECT COUNT(*) AS cnt FROM %s WHERE %s = TO_UUID('%s')", getTableName(),
+            UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(1).toUpperCase()),
+        String.format("SELECT BYTES_TO_UUID(%s) AS uuidValue, COUNT(*) AS cnt FROM %s "
+                + "GROUP BY BYTES_TO_UUID(%s) ORDER BY uuidValue",
+            UUID_AS_BYTES_COLUMN, getTableName(), UUID_AS_BYTES_COLUMN));
+
+    for (String query : queries) {
+      JsonNode sseResult = postResultTable(false, query);
+      JsonNode mseResult = postResultTable(true, query);
+      assertEquals(mseResult, sseResult, query);
+    }
+  }
+
+  /**
+   * Regression for the DISTINCTCOUNT-family canonical-string contract: for identifier expressions the
+   * aggregation receives a ProjectionBlockValSet whose getStringValuesSV() renders stored BYTES as bare hex,
+   * so the UUID branches must fetch raw bytes and canonicalize themselves. Asserts
+   * DISTINCTCOUNTX(uuidCol) == DISTINCTCOUNTX(CAST(uuidCol AS STRING)) end-to-end on real segments —
+   * a parity that silently breaks if any branch falls back to the projection string path.
+   */
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testDistinctCountFamilyUuidMatchesCastStringParity(boolean useMultiStageQueryEngine)
+      throws Exception {
+    for (String function : List.of("DISTINCTCOUNT", "DISTINCTCOUNTBITMAP", "DISTINCTCOUNTHLL",
+        "DISTINCTCOUNTHLLPLUS", "DISTINCTCOUNTULL", "DISTINCTCOUNTCPCSKETCH", "DISTINCTCOUNTTHETASKETCH")) {
+      String onUuid = String.format("SELECT %s(%s) FROM %s", function, UUID_FROM_STRING_COLUMN, getTableName());
+      String onCastString = String.format("SELECT %s(CAST(%s AS STRING)) FROM %s", function,
+          UUID_FROM_STRING_COLUMN, getTableName());
+      JsonNode uuidRows = postRows(useMultiStageQueryEngine, onUuid);
+      JsonNode castRows = postRows(useMultiStageQueryEngine, onCastString);
+      assertEquals(uuidRows.get(0).get(0).asLong(), castRows.get(0).get(0).asLong(),
+          function + " on UUID column must match the same function on CAST(uuidCol AS STRING)");
+      assertEquals(uuidRows.get(0).get(0).asLong(), DISTINCT_UUID_VALUES.size(),
+          function + " on UUID column must count the distinct UUID values");
+    }
+
+    // Also pin the filterless dictionary-based plan (NonScanBasedAggregationOperator): a WHERE clause forces the
+    // scan path above on some engines, while the bare aggregates here may be served purely from the dictionary.
+    // Both shapes must agree for UUID columns.
+    JsonNode filteredRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT DISTINCTCOUNTHLL(%s) FROM %s WHERE %s >= 0", UUID_FROM_STRING_COLUMN, getTableName(), ID_COLUMN));
+    JsonNode unfilteredRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT DISTINCTCOUNTHLL(%s) FROM %s", UUID_FROM_STRING_COLUMN, getTableName()));
+    assertEquals(unfilteredRows.get(0).get(0).asLong(), filteredRows.get(0).get(0).asLong(),
+        "Dictionary-based (filterless) and scan-based DISTINCTCOUNTHLL must agree on UUID columns");
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testUuidEqualityJoinWithExpressionKey(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT a.%s, b.%s, a.%s "
+            + "FROM (SELECT %s, %s FROM %s WHERE %s < 5) a "
+            + "JOIN (SELECT %s, %s, %s FROM %s WHERE %s > 0) b "
+            + "ON a.%s = BYTES_TO_UUID(UUID_TO_BYTES(b.%s)) "
+            + "WHERE a.%s < b.%s "
+            + "ORDER BY a.%s, b.%s",
+        ID_COLUMN, ID_COLUMN, UUID_FROM_STRING_COLUMN, ID_COLUMN, UUID_FROM_STRING_COLUMN, getTableName(), ID_COLUMN,
+        ID_COLUMN, UUID_FROM_BYTES_COLUMN, UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN, UUID_FROM_STRING_COLUMN,
+        UUID_FROM_BYTES_COLUMN, ID_COLUMN, ID_COLUMN, ID_COLUMN, ID_COLUMN));
+
+    assertEquals(rows.size(), 2);
+    assertEquals(rows.get(0).get(0).asInt(), 0);
+    assertEquals(rows.get(0).get(1).asInt(), 2);
+    assertEquals(rows.get(0).get(2).asText(), DISTINCT_UUID_VALUES.get(0));
+    assertEquals(rows.get(1).get(0).asInt(), 1);
+    assertEquals(rows.get(1).get(1).asInt(), 4);
+    assertEquals(rows.get(1).get(2).asText(), DISTINCT_UUID_VALUES.get(1));
+  }
+
+  /**
+   * LEFT JOIN on a UUID key with unmatched left rows: ids 0 and 2 carry the only UUID (…440000) absent from the
+   * right side (id >= 3), so they must surface with a NULL right id while every other row matches. Locks in
+   * UuidLookupTable/HashJoinOperator key normalization for the non-INNER join paths.
+   */
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testUuidLeftJoin(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT a.%s, b.%s "
+            + "FROM (SELECT %s, %s FROM %s) a "
+            + "LEFT JOIN (SELECT %s, %s FROM %s WHERE %s >= 3) b "
+            + "ON a.%s = b.%s "
+            + "ORDER BY a.%s, b.%s",
+        ID_COLUMN, ID_COLUMN,
+        ID_COLUMN, UUID_FROM_STRING_COLUMN, getTableName(),
+        ID_COLUMN, UUID_FROM_STRING_COLUMN, getTableName(), ID_COLUMN,
+        UUID_FROM_STRING_COLUMN, UUID_FROM_STRING_COLUMN,
+        ID_COLUMN, ID_COLUMN));
+
+    // Left ids 0 and 2 (uuid …440000) have no right match; 1 and 4 match right id 4 (…440001); 3 matches 3;
+    // 5 matches 5.
+    assertEquals(rows.size(), 6);
+    assertEquals(rows.get(0).get(0).asInt(), 0);
+    assertTrue(rows.get(0).get(1).isNull(), "Left row with unmatched UUID must produce NULL right id");
+    assertEquals(rows.get(1).get(0).asInt(), 1);
+    assertEquals(rows.get(1).get(1).asInt(), 4);
+    assertEquals(rows.get(2).get(0).asInt(), 2);
+    assertTrue(rows.get(2).get(1).isNull(), "Left row with unmatched UUID must produce NULL right id");
+    assertEquals(rows.get(3).get(0).asInt(), 3);
+    assertEquals(rows.get(3).get(1).asInt(), 3);
+    assertEquals(rows.get(4).get(0).asInt(), 4);
+    assertEquals(rows.get(4).get(1).asInt(), 4);
+    assertEquals(rows.get(5).get(0).asInt(), 5);
+    assertEquals(rows.get(5).get(1).asInt(), 5);
+  }
+
+  /**
+   * SEMI and ANTI joins on a UUID key (planned from IN / NOT IN subqueries in the multi-stage engine). The right
+   * side carries UUIDs of ids >= 3 ({…440001, …440002, …440003}); ids 1/3/4/5 are semi-matched and ids 0/2
+   * (uuid …440000) are anti-matched.
+   */
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testUuidSemiAndAntiJoin(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode semiRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s IN (SELECT %s FROM %s WHERE %s >= 3) ORDER BY %s",
+        ID_COLUMN, getTableName(), UUID_FROM_STRING_COLUMN,
+        UUID_FROM_STRING_COLUMN, getTableName(), ID_COLUMN, ID_COLUMN));
+    assertIdRows(semiRows, 1, 3, 4, 5);
+
+    JsonNode antiRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s NOT IN (SELECT %s FROM %s WHERE %s >= 3) ORDER BY %s",
+        ID_COLUMN, getTableName(), UUID_FROM_STRING_COLUMN,
+        UUID_FROM_STRING_COLUMN, getTableName(), ID_COLUMN, ID_COLUMN));
+    assertIdRows(antiRows, 0, 2);
+  }
+
+  private JsonNode postRows(boolean useMultiStageQueryEngine, String query)
+      throws Exception {
+    return postResultTable(useMultiStageQueryEngine, query).get("rows");
+  }
+
+  private JsonNode postResultTable(boolean useMultiStageQueryEngine, String query)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    JsonNode response = postQuery(query);
+    assertNoExceptions(response);
+    return response.get("resultTable");
+  }
+
+  private static void assertGroupedCounts(JsonNode rows) {
+    assertEquals(rows.size(), DISTINCT_UUID_VALUES.size());
+    assertEquals(rows.get(0).get(0).asText(), DISTINCT_UUID_VALUES.get(0));
+    assertEquals(rows.get(0).get(1).asInt(), 2);
+    assertEquals(rows.get(1).get(0).asText(), DISTINCT_UUID_VALUES.get(1));
+    assertEquals(rows.get(1).get(1).asInt(), 2);
+    assertEquals(rows.get(2).get(0).asText(), DISTINCT_UUID_VALUES.get(2));
+    assertEquals(rows.get(2).get(1).asInt(), 1);
+    assertEquals(rows.get(3).get(0).asText(), DISTINCT_UUID_VALUES.get(3));
+    assertEquals(rows.get(3).get(1).asInt(), 1);
+  }
+
+  private static void assertDistinctRows(JsonNode rows) {
+    assertEquals(rows.size(), DISTINCT_UUID_VALUES.size());
+    for (int i = 0; i < DISTINCT_UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), DISTINCT_UUID_VALUES.get(i));
+    }
+  }
+
+  private static void assertIdRows(JsonNode rows, int... expectedIds) {
+    assertEquals(rows.size(), expectedIds.length);
+    for (int i = 0; i < expectedIds.length; i++) {
+      assertEquals(rows.get(i).get(0).asInt(), expectedIds[i]);
+    }
+  }
+
+  private static GenericData.Array<String> uuidStringArray(int rowIndex, org.apache.avro.Schema schema) {
+    GenericData.Array<String> array = new GenericData.Array<>(2, schema);
+    array.add(UUID_INPUT_VALUES.get(rowIndex));
+    array.add(UUID_INPUT_VALUES.get((rowIndex + 1) % UUID_INPUT_VALUES.size()));
+    return array;
+  }
+
+  private static GenericData.Array<ByteBuffer> uuidBytesArray(int rowIndex, org.apache.avro.Schema schema) {
+    GenericData.Array<ByteBuffer> array = new GenericData.Array<>(2, schema);
+    array.add(ByteBuffer.wrap(UuidUtils.toBytes(UUID_INPUT_VALUES.get(rowIndex))));
+    array.add(ByteBuffer.wrap(UuidUtils.toBytes(UUID_INPUT_VALUES.get((rowIndex + 1) % UUID_INPUT_VALUES.size()))));
+    return array;
+  }
+
+  private static void assertUuidArray(JsonNode array, int rowIndex) {
+    assertEquals(array.size(), 2);
+    assertEquals(array.get(0).asText(), UUID_VALUES.get(rowIndex));
+    assertEquals(array.get(1).asText(), UUID_VALUES.get((rowIndex + 1) % UUID_VALUES.size()));
+  }
+
+  private static String uuidHex(String uuidValue) {
+    return BytesUtils.toHexString(UuidUtils.toBytes(uuidValue));
+  }
+
+  private static void assertNoExceptions(JsonNode response) {
+    assertEquals(response.get("exceptions").size(), 0, response.toPrettyString());
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidUpsertRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidUpsertRealtimeTest.java
@@ -1,0 +1,339 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.integration.tests.ClusterTest.AvroFileSchemaKafkaAvroMessageDecoder;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
+import org.apache.pinot.spi.config.table.RoutingConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Realtime upsert coverage for UUID primary keys.
+ *
+ * <p>This test uses a single Kafka partition. UUID primary keys must be in canonical lowercase form (enforced at
+ * ingestion time by {@code DataTypeTransformer}) because Kafka partition routing is determined by the raw string value
+ * before Pinot normalization; non-canonical values would cause silent dedup failures in multi-partition tables.
+ */
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class UuidUpsertRealtimeTest extends CustomDataQueryClusterIntegrationTest {
+  private static final long DEDUPLICATED_RECORDS_READY_TIMEOUT_MS = 120_000L;
+  private static final String TABLE_NAME = "UuidUpsertRealtimeTest";
+  private static final String UUID_PK_COLUMN = "uuidPk";
+  private static final String PAYLOAD_COLUMN = "payload";
+  private static final String TIME_COLUMN = "ts";
+  // All primary key values must be canonical lowercase UUIDs. DataTypeTransformer rejects non-canonical
+  // (uppercase) UUID primary keys for upsert tables to prevent silent dedup failures when the same
+  // logical UUID is routed to different Kafka partitions before normalization.
+  private static final List<String> UUID_INPUT_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440000",  // duplicate of index 0, triggers upsert dedup
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550e8400-e29b-41d4-a716-446655440001"); // duplicate of index 1, triggers upsert dedup
+  private static final List<String> PAYLOAD_VALUES = List.of("alpha-v1", "beta-v1", "alpha-v2", "gamma-v1",
+      "beta-v2");
+  private static final List<String> EXPECTED_UUID_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440002");
+  private static final List<String> EXPECTED_PAYLOAD_VALUES = List.of("alpha-v2", "beta-v2", "gamma-v1");
+  private static final String COUNT_QUERY = String.format("SELECT COUNT(*) FROM %s", TABLE_NAME);
+  private static final String RAW_COUNT_QUERY =
+      String.format("SELECT COUNT(*) FROM %s OPTION(skipUpsert=true)", TABLE_NAME);
+  private static final String ORDERED_ROWS_QUERY =
+      String.format("SELECT %s, %s FROM %s ORDER BY %s", UUID_PK_COLUMN, PAYLOAD_COLUMN, TABLE_NAME, UUID_PK_COLUMN);
+  private static final String FILTER_QUERY = String.format("SELECT %s FROM %s WHERE %s = TO_UUID('%s')",
+      PAYLOAD_COLUMN, TABLE_NAME, UUID_PK_COLUMN, UUID_INPUT_VALUES.get(0));
+  private static final int TOTAL_RAW_RECORDS = UUID_INPUT_VALUES.size();
+  private static final long BASE_TIMESTAMP_MILLIS = 1_700_100_000_000L;
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+
+  @Override
+  public String getTimeColumnName() {
+    return TIME_COLUMN;
+  }
+
+  @Override
+  protected UpsertConfig getUpsertConfig() {
+    return new UpsertConfig(UpsertConfig.Mode.FULL);
+  }
+
+  @Override
+  protected RoutingConfig getRoutingConfig() {
+    return new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return EXPECTED_UUID_VALUES.size();
+  }
+
+  @Override
+  protected int getNumKafkaPartitions() {
+    return 1;
+  }
+
+  @Override
+  public int getNumAvroFiles() {
+    return 1;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return 2;
+  }
+
+  @Override
+  protected TableConfig createRealtimeTableConfig(File sampleAvroFile) {
+    AvroFileSchemaKafkaAvroMessageDecoder._avroFile = sampleAvroFile;
+    SegmentPartitionConfig segmentPartitionConfig = new SegmentPartitionConfig(
+        Map.of(UUID_PK_COLUMN, new ColumnPartitionConfig("Murmur", getNumKafkaPartitions())));
+    return getTableConfigBuilder(TableType.REALTIME)
+        .setSegmentPartitionConfig(segmentPartitionConfig)
+        .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(UUID_PK_COLUMN, 1))
+        .build();
+  }
+
+  @Override
+  protected void waitForAllDocsLoaded(long timeoutMs)
+      throws Exception {
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return queryCountStarWithoutUpsert() == TOTAL_RAW_RECORDS;
+      } catch (Exception e) {
+        return null;
+      }
+    }, 100L, timeoutMs, "Failed to load raw UUID upsert records");
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(UUID_PK_COLUMN, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(PAYLOAD_COLUMN, FieldSpec.DataType.STRING)
+        .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .setPrimaryKeyColumns(List.of(UUID_PK_COLUMN))
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("uuidUpsertRecord", null, null, false);
+    avroSchema.setFields(List.of(
+        new Field(UUID_PK_COLUMN, create(Type.STRING), null, null),
+        new Field(PAYLOAD_COLUMN, create(Type.STRING), null, null),
+        new Field(TIME_COLUMN, create(Type.LONG), null, null)));
+
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < UUID_INPUT_VALUES.size(); i++) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(UUID_PK_COLUMN, UUID_INPUT_VALUES.get(i));
+        record.put(PAYLOAD_COLUMN, PAYLOAD_VALUES.get(i));
+        record.put(TIME_COLUMN, BASE_TIMESTAMP_MILLIS + i);
+        writers.get(0).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testUuidPrimaryKeyUpsertDedup(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    UuidQueryResults queryResults = waitForExpectedQueryResults(DEDUPLICATED_RECORDS_READY_TIMEOUT_MS);
+
+    assertExpectedCountResponse(queryResults._countResponse, EXPECTED_UUID_VALUES.size());
+    assertExpectedCountResponse(queryResults._rawCountResponse, TOTAL_RAW_RECORDS);
+    assertExpectedOrderedRowsResponse(queryResults._orderedRowsResponse);
+    assertExpectedFilterResponse(queryResults._filterResponse);
+  }
+
+  private static void assertNoExceptions(JsonNode response) {
+    assertEquals(getExceptionCount(response), 0, response.toPrettyString());
+  }
+
+  private void assertExpectedCountResponse(JsonNode response, long expectedCount) {
+    assertNoExceptions(response);
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    assertNotNull(firstRowFirstColumn, response.toPrettyString());
+    assertEquals(firstRowFirstColumn.asLong(), expectedCount);
+  }
+
+  private void assertExpectedOrderedRowsResponse(JsonNode response) {
+    assertNoExceptions(response);
+    JsonNode rows = getRows(response);
+    assertNotNull(rows, response.toPrettyString());
+    assertEquals(rows.size(), EXPECTED_UUID_VALUES.size());
+    for (int i = 0; i < EXPECTED_UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), EXPECTED_UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(1).asText(), EXPECTED_PAYLOAD_VALUES.get(i));
+    }
+  }
+
+  private void assertExpectedFilterResponse(JsonNode response) {
+    assertNoExceptions(response);
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    assertNotNull(firstRowFirstColumn, response.toPrettyString());
+    assertEquals(firstRowFirstColumn.asText(), "alpha-v2");
+  }
+
+  private UuidQueryResults waitForExpectedQueryResults(long timeoutMs)
+      throws Exception {
+    AtomicReference<UuidQueryResults> queryResultsRef = new AtomicReference<>();
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        UuidQueryResults queryResults = fetchQueryResults();
+        if (matchesExpectedQueryResults(queryResults)) {
+          queryResultsRef.set(queryResults);
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        return null;
+      }
+    }, 100L, timeoutMs, "Failed to observe expected UUID upsert query results");
+    return queryResultsRef.get();
+  }
+
+  private UuidQueryResults fetchQueryResults()
+      throws Exception {
+    return new UuidQueryResults(postQuery(COUNT_QUERY), postQuery(RAW_COUNT_QUERY), postQuery(ORDERED_ROWS_QUERY),
+        postQuery(FILTER_QUERY));
+  }
+
+  private boolean matchesExpectedQueryResults(UuidQueryResults queryResults) {
+    return hasExpectedCount(queryResults._countResponse, EXPECTED_UUID_VALUES.size())
+        && hasExpectedCount(queryResults._rawCountResponse, TOTAL_RAW_RECORDS)
+        && hasExpectedOrderedRows(queryResults._orderedRowsResponse)
+        && hasExpectedFilterValue(queryResults._filterResponse, "alpha-v2");
+  }
+
+  private boolean hasExpectedCount(JsonNode response, long expectedCount) {
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    return hasNoExceptions(response) && firstRowFirstColumn != null
+        && firstRowFirstColumn.asLong(Long.MIN_VALUE) == expectedCount;
+  }
+
+  private boolean hasExpectedOrderedRows(JsonNode response) {
+    if (!hasNoExceptions(response)) {
+      return false;
+    }
+    JsonNode rows = getRows(response);
+    if (rows == null) {
+      return false;
+    }
+    if (rows.size() != EXPECTED_UUID_VALUES.size()) {
+      return false;
+    }
+    for (int i = 0; i < EXPECTED_UUID_VALUES.size(); i++) {
+      JsonNode row = rows.get(i);
+      if (row == null || row.size() < 2 || !EXPECTED_UUID_VALUES.get(i).equals(row.get(0).asText())
+          || !EXPECTED_PAYLOAD_VALUES.get(i).equals(row.get(1).asText())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean hasExpectedFilterValue(JsonNode response, String expectedValue) {
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    return hasNoExceptions(response) && firstRowFirstColumn != null
+        && expectedValue.equals(firstRowFirstColumn.asText());
+  }
+
+  private static boolean hasNoExceptions(JsonNode response) {
+    return getExceptionCount(response) == 0;
+  }
+
+  private static int getExceptionCount(JsonNode response) {
+    JsonNode exceptions = response.get("exceptions");
+    return exceptions != null ? exceptions.size() : 0;
+  }
+
+  private static JsonNode getRows(JsonNode response) {
+    JsonNode resultTable = response.get("resultTable");
+    if (resultTable == null) {
+      return null;
+    }
+    return resultTable.get("rows");
+  }
+
+  private static JsonNode getFirstRowFirstColumn(JsonNode response) {
+    JsonNode rows = getRows(response);
+    if (rows == null || rows.isEmpty()) {
+      return null;
+    }
+    JsonNode firstRow = rows.get(0);
+    if (firstRow == null || firstRow.isEmpty()) {
+      return null;
+    }
+    return firstRow.get(0);
+  }
+
+  private long queryCountStarWithoutUpsert() {
+    return getPinotConnection().execute(RAW_COUNT_QUERY).getResultSet(0).getLong(0);
+  }
+
+  private static final class UuidQueryResults {
+    private final JsonNode _countResponse;
+    private final JsonNode _rawCountResponse;
+    private final JsonNode _orderedRowsResponse;
+    private final JsonNode _filterResponse;
+
+    private UuidQueryResults(JsonNode countResponse, JsonNode rawCountResponse, JsonNode orderedRowsResponse,
+        JsonNode filterResponse) {
+      _countResponse = countResponse;
+      _rawCountResponse = rawCountResponse;
+      _orderedRowsResponse = orderedRowsResponse;
+      _filterResponse = filterResponse;
+    }
+  }
+}

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -51,6 +51,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-query-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-kafka-3.0</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidGroupingAndLookup.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidGroupingAndLookup.java
@@ -1,0 +1,276 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.query.runtime.operator.groupby.OneObjectKeyGroupIdGenerator;
+import org.apache.pinot.query.runtime.operator.groupby.OneUuidKeyGroupIdGenerator;
+import org.apache.pinot.query.runtime.operator.join.ObjectLookupTable;
+import org.apache.pinot.query.runtime.operator.join.UuidLookupTable;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/**
+ * Benchmarks UUID grouping and lookup hot paths using Pinot's current {@link ByteArray}-based representation versus a
+ * two-long UUID key representation and {@link UUID}.
+ *
+ * <p>The benchmark is intentionally engine-adjacent:
+ * <ul>
+ *   <li>V1 grouping uses the same {@code Object2IntOpenHashMap<ByteArray>} shape as no-dictionary UUID group-by</li>
+ *   <li>V2 grouping uses {@link OneUuidKeyGroupIdGenerator}</li>
+ *   <li>Lookup uses {@link UuidLookupTable}, which is the UUID-specific path used by MSE hash join</li>
+ * </ul>
+ */
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@State(Scope.Benchmark)
+public class BenchmarkUuidGroupingAndLookup {
+  private static final long RANDOM_SEED = 677_280_899_123L;
+
+  @Param({"262144"})
+  public int _numRows;
+
+  @Param({"65536"})
+  public int _cardinality;
+
+  @Param({"8192"})
+  public int _numProbes;
+
+  private byte[][] _rowUuidBytes;
+  private ByteArray[] _rowByteArrays;
+  private UuidKey[] _rowUuidKeys;
+  private UUID[] _rowJavaUuids;
+  private ByteArray[] _distinctByteArrays;
+  private UuidKey[] _distinctUuidKeys;
+  private UUID[] _distinctJavaUuids;
+  private Object[][] _distinctByteArrayRows;
+  private Object[][] _distinctJavaUuidRows;
+  private ByteArray[] _probeByteArrays;
+  private UUID[] _probeJavaUuids;
+
+  @Setup
+  public void setUp() {
+    Random random = new Random(RANDOM_SEED);
+
+    byte[][] distinctUuidBytes = new byte[_cardinality][];
+    _distinctByteArrays = new ByteArray[_cardinality];
+    _distinctUuidKeys = new UuidKey[_cardinality];
+    _distinctJavaUuids = new UUID[_cardinality];
+    _distinctByteArrayRows = new Object[_cardinality][];
+    _distinctJavaUuidRows = new Object[_cardinality][];
+
+    for (int i = 0; i < _cardinality; i++) {
+      UUID uuid = new UUID(random.nextLong(), random.nextLong());
+      byte[] uuidBytes = UuidUtils.toBytes(uuid);
+
+      distinctUuidBytes[i] = uuidBytes;
+      _distinctByteArrays[i] = new ByteArray(uuidBytes);
+      _distinctUuidKeys[i] = UuidKey.fromLongs(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+      _distinctJavaUuids[i] = uuid;
+      _distinctByteArrayRows[i] = new Object[]{i};
+      _distinctJavaUuidRows[i] = new Object[]{i};
+    }
+
+    _rowUuidBytes = new byte[_numRows][];
+    _rowByteArrays = new ByteArray[_numRows];
+    _rowUuidKeys = new UuidKey[_numRows];
+    _rowJavaUuids = new UUID[_numRows];
+
+    for (int i = 0; i < _numRows; i++) {
+      int dictId = random.nextInt(_cardinality);
+      _rowUuidBytes[i] = distinctUuidBytes[dictId];
+      _rowByteArrays[i] = _distinctByteArrays[dictId];
+      _rowUuidKeys[i] = _distinctUuidKeys[dictId];
+      _rowJavaUuids[i] = _distinctJavaUuids[dictId];
+    }
+
+    _probeByteArrays = new ByteArray[_numProbes];
+    _probeJavaUuids = new UUID[_numProbes];
+    for (int i = 0; i < _numProbes; i++) {
+      int dictId = random.nextInt(_cardinality);
+      _probeByteArrays[i] = _distinctByteArrays[dictId];
+      _probeJavaUuids[i] = _distinctJavaUuids[dictId];
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v1CurrentByteArrayGrouping() {
+    Object2IntOpenHashMap<ByteArray> groupIdMap = new Object2IntOpenHashMap<>(_cardinality);
+    groupIdMap.defaultReturnValue(-1);
+
+    int checksum = 0;
+    for (int i = 0; i < _numRows; i++) {
+      checksum += getOrCreateGroupId(groupIdMap, new ByteArray(_rowUuidBytes[i]));
+    }
+    return checksum + groupIdMap.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v1UuidKeyGrouping() {
+    Object2IntOpenHashMap<UuidKey> groupIdMap = new Object2IntOpenHashMap<>(_cardinality);
+    groupIdMap.defaultReturnValue(-1);
+
+    int checksum = 0;
+    for (int i = 0; i < _numRows; i++) {
+      checksum += getOrCreateGroupId(groupIdMap, _rowUuidKeys[i]);
+    }
+    return checksum + groupIdMap.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v1JavaUuidGrouping() {
+    Object2IntOpenHashMap<UUID> groupIdMap = new Object2IntOpenHashMap<>(_cardinality);
+    groupIdMap.defaultReturnValue(-1);
+
+    int checksum = 0;
+    for (int i = 0; i < _numRows; i++) {
+      checksum += getOrCreateGroupId(groupIdMap, _rowJavaUuids[i]);
+    }
+    return checksum + groupIdMap.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v2CurrentByteArrayGroupIdGenerator() {
+    OneObjectKeyGroupIdGenerator groupIdGenerator = new OneObjectKeyGroupIdGenerator(_cardinality, _cardinality);
+
+    int checksum = 0;
+    for (ByteArray rowByteArray : _rowByteArrays) {
+      checksum += groupIdGenerator.getGroupId(rowByteArray);
+    }
+    return checksum + groupIdGenerator.getNumGroups();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v2UuidKeyGroupIdGenerator() {
+    OneUuidKeyGroupIdGenerator groupIdGenerator = new OneUuidKeyGroupIdGenerator(_cardinality, _cardinality);
+
+    int checksum = 0;
+    for (UuidKey rowUuidKey : _rowUuidKeys) {
+      checksum += groupIdGenerator.getGroupId(rowUuidKey);
+    }
+    return checksum + groupIdGenerator.getNumGroups();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v2JavaUuidGroupIdGenerator() {
+    OneObjectKeyGroupIdGenerator groupIdGenerator = new OneObjectKeyGroupIdGenerator(_cardinality, _cardinality);
+
+    int checksum = 0;
+    for (UUID rowJavaUuid : _rowJavaUuids) {
+      checksum += groupIdGenerator.getGroupId(rowJavaUuid);
+    }
+    return checksum + groupIdGenerator.getNumGroups();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int currentObjectLookupTableBuildAndProbe() {
+    ObjectLookupTable lookupTable = new ObjectLookupTable();
+    for (int i = 0; i < _cardinality; i++) {
+      lookupTable.addRow(_distinctByteArrays[i], _distinctByteArrayRows[i]);
+    }
+    lookupTable.finish();
+
+    int checksum = lookupTable.size();
+    for (ByteArray probeByteArray : _probeByteArrays) {
+      Object[] row = (Object[]) lookupTable.lookup(probeByteArray);
+      if (row != null) {
+        checksum += (int) row[0];
+      }
+    }
+    return checksum;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int uuidLookupTableBuildAndProbe() {
+    UuidLookupTable lookupTable = new UuidLookupTable();
+    for (int i = 0; i < _cardinality; i++) {
+      lookupTable.addRow(_distinctByteArrays[i], _distinctByteArrayRows[i]);
+    }
+    lookupTable.finish();
+
+    int checksum = lookupTable.size();
+    for (ByteArray probeByteArray : _probeByteArrays) {
+      Object[] row = (Object[]) lookupTable.lookup(probeByteArray);
+      if (row != null) {
+        checksum += (int) row[0];
+      }
+    }
+    return checksum;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int javaUuidObjectLookupTableBuildAndProbe() {
+    ObjectLookupTable lookupTable = new ObjectLookupTable();
+    for (int i = 0; i < _cardinality; i++) {
+      lookupTable.addRow(_distinctJavaUuids[i], _distinctJavaUuidRows[i]);
+    }
+    lookupTable.finish();
+
+    int checksum = lookupTable.size();
+    for (UUID probeJavaUuid : _probeJavaUuids) {
+      Object[] row = (Object[]) lookupTable.lookup(probeJavaUuid);
+      if (row != null) {
+        checksum += (int) row[0];
+      }
+    }
+    return checksum;
+  }
+
+  private <T> int getOrCreateGroupId(Object2IntOpenHashMap<T> groupIdMap, T key) {
+    int numGroups = groupIdMap.size();
+    if (numGroups < _cardinality) {
+      return groupIdMap.computeIfAbsent(key, ignored -> numGroups);
+    }
+    return groupIdMap.getInt(key);
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkUuidGroupingAndLookup.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidQueryExecution.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidQueryExecution.java
@@ -1,0 +1,363 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.queries.BaseQueriesTest;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/**
+ * Compares query execution performance for UUID values stored in three representations:
+ * <ul>
+ *   <li><b>STRING</b> — canonical RFC 4122 form, e.g. {@code "550e8400-e29b-41d4-a716-446655440000"} (36-char string
+ *   key in group-by)</li>
+ *   <li><b>BYTES</b> — raw 16-byte binary; group-by key is a {@code ByteArray} (heap allocation per row)</li>
+ *   <li><b>UUID</b> — native {@code DataType.UUID}; group-by key is a {@code UuidKey} (two {@code long} fields,
+ *   no heap allocation)</li>
+ * </ul>
+ * Each representation is tested with both raw (no-dictionary) and dictionary-encoded columns. The benchmarked
+ * operations are GROUP BY, COUNT(DISTINCT), and equality-filter COUNT(*).
+ *
+ * <p>Run with:
+ * <pre>
+ *   ./mvnw package -DskipTests -pl pinot-perf -am -Ppinot-fastdev
+ *   java -jar pinot-perf/target/benchmarks.jar BenchmarkUuidQueryExecution
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+@State(Scope.Benchmark)
+public class BenchmarkUuidQueryExecution extends BaseQueriesTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), "BenchmarkUuidQueryExecution");
+  private static final String TABLE_NAME = "uuidBenchTable";
+  private static final String SEGMENT_NAME = "uuidBenchSegment";
+
+  // STRING columns: UUID in canonical "8-4-4-4-12" dash-separated form
+  private static final String STR_UUID_RAW = "str_uuid_raw";
+  private static final String STR_UUID_DICT = "str_uuid_dict";
+  // BYTES columns: UUID as raw 16-byte binary; group-by uses ByteArray
+  private static final String BYTES_UUID_RAW = "bytes_uuid_raw";
+  private static final String BYTES_UUID_DICT = "bytes_uuid_dict";
+  // UUID columns: native DataType.UUID; group-by uses UuidKey (two longs)
+  private static final String UUID_RAW = "uuid_raw";
+  private static final String UUID_DICT = "uuid_dict";
+  // Two-LONG columns: UUID split into MSB + LSB; GROUP BY both simultaneously
+  private static final String LONG_MSB_RAW = "long_msb_raw";
+  private static final String LONG_LSB_RAW = "long_lsb_raw";
+  private static final String LONG_MSB_DICT = "long_msb_dict";
+  private static final String LONG_LSB_DICT = "long_lsb_dict";
+
+  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName(TABLE_NAME)
+      .setNoDictionaryColumns(List.of(STR_UUID_RAW, BYTES_UUID_RAW, UUID_RAW, LONG_MSB_RAW, LONG_LSB_RAW))
+      .build();
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder()
+      .addSingleValueDimension(STR_UUID_RAW, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(STR_UUID_DICT, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(BYTES_UUID_RAW, FieldSpec.DataType.BYTES)
+      .addSingleValueDimension(BYTES_UUID_DICT, FieldSpec.DataType.BYTES)
+      .addSingleValueDimension(UUID_RAW, FieldSpec.DataType.UUID)
+      .addSingleValueDimension(UUID_DICT, FieldSpec.DataType.UUID)
+      .addSingleValueDimension(LONG_MSB_RAW, FieldSpec.DataType.LONG)
+      .addSingleValueDimension(LONG_LSB_RAW, FieldSpec.DataType.LONG)
+      .addSingleValueDimension(LONG_MSB_DICT, FieldSpec.DataType.LONG)
+      .addSingleValueDimension(LONG_LSB_DICT, FieldSpec.DataType.LONG)
+      .build();
+
+  /** Total rows in the segment. */
+  @Param("500000")
+  private int _numRows;
+
+  /** Number of distinct UUID values. Controls group-by cardinality. */
+  @Param("1000")
+  private int _numUniqueUuids;
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  /** UUID string used in equality-filter benchmarks (RFC 4122 form). */
+  private String _filterUuidString;
+  /** Same UUID as hex (no dashes) for BYTES column equality filter. */
+  private String _filterBytesHex;
+  /** MSB of the filter UUID, for two-long filter benchmarks. */
+  private long _filterMsb;
+  /** LSB of the filter UUID, for two-long filter benchmarks. */
+  private long _filterLsb;
+
+  @Setup
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+    INDEX_DIR.mkdirs();
+
+    Random random = new Random(42L);
+
+    // Pre-generate the UUID value pool
+    String[] uuidStrings = new String[_numUniqueUuids];
+    byte[][] uuidBytesArr = new byte[_numUniqueUuids][];
+    long[] msbArr = new long[_numUniqueUuids];
+    long[] lsbArr = new long[_numUniqueUuids];
+    for (int i = 0; i < _numUniqueUuids; i++) {
+      UUID uuid = new UUID(random.nextLong(), random.nextLong());
+      uuidStrings[i] = uuid.toString();
+      uuidBytesArr[i] = UuidUtils.toBytes(uuid);
+      msbArr[i] = uuid.getMostSignificantBits();
+      lsbArr[i] = uuid.getLeastSignificantBits();
+    }
+    _filterUuidString = uuidStrings[0];
+    _filterBytesHex = BytesUtils.toHexString(uuidBytesArr[0]);
+    _filterMsb = msbArr[0];
+    _filterLsb = lsbArr[0];
+
+    // Build rows with uniform distribution over the UUID pool
+    List<GenericRow> rows = new ArrayList<>(_numRows);
+    for (int i = 0; i < _numRows; i++) {
+      int idx = i % _numUniqueUuids;
+      GenericRow row = new GenericRow();
+      row.putValue(STR_UUID_RAW, uuidStrings[idx]);
+      row.putValue(STR_UUID_DICT, uuidStrings[idx]);
+      row.putValue(BYTES_UUID_RAW, uuidBytesArr[idx]);
+      row.putValue(BYTES_UUID_DICT, uuidBytesArr[idx]);
+      row.putValue(UUID_RAW, uuidBytesArr[idx]);
+      row.putValue(UUID_DICT, uuidBytesArr[idx]);
+      row.putValue(LONG_MSB_RAW, msbArr[idx]);
+      row.putValue(LONG_LSB_RAW, lsbArr[idx]);
+      row.putValue(LONG_MSB_DICT, msbArr[idx]);
+      row.putValue(LONG_LSB_DICT, lsbArr[idx]);
+      rows.add(row);
+    }
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    IndexLoadingConfig loadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), loadingConfig);
+    _indexSegments = List.of(_indexSegment);
+  }
+
+  @TearDown
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  // ---- GROUP BY --------------------------------------------------------
+
+  @Benchmark
+  public BrokerResponseNative groupByStrUuidRaw() {
+    return getBrokerResponse(
+        "SELECT " + STR_UUID_RAW + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + STR_UUID_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByStrUuidDict() {
+    return getBrokerResponse(
+        "SELECT " + STR_UUID_DICT + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + STR_UUID_DICT);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByBytesUuidRaw() {
+    return getBrokerResponse(
+        "SELECT " + BYTES_UUID_RAW + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + BYTES_UUID_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByBytesUuidDict() {
+    return getBrokerResponse(
+        "SELECT " + BYTES_UUID_DICT + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + BYTES_UUID_DICT);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByNativeUuidRaw() {
+    return getBrokerResponse(
+        "SELECT " + UUID_RAW + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + UUID_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByNativeUuidDict() {
+    return getBrokerResponse(
+        "SELECT " + UUID_DICT + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + UUID_DICT);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByTwoLongRaw() {
+    return getBrokerResponse(
+        "SELECT " + LONG_MSB_RAW + ", " + LONG_LSB_RAW + ", COUNT(*) FROM " + TABLE_NAME
+            + " GROUP BY " + LONG_MSB_RAW + ", " + LONG_LSB_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByTwoLongDict() {
+    return getBrokerResponse(
+        "SELECT " + LONG_MSB_DICT + ", " + LONG_LSB_DICT + ", COUNT(*) FROM " + TABLE_NAME
+            + " GROUP BY " + LONG_MSB_DICT + ", " + LONG_LSB_DICT);
+  }
+
+  // ---- COUNT(DISTINCT) ------------------------------------------------
+
+  @Benchmark
+  public BrokerResponseNative countDistinctStrUuidRaw() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + STR_UUID_RAW + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctStrUuidDict() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + STR_UUID_DICT + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctBytesUuidRaw() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + BYTES_UUID_RAW + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctBytesUuidDict() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + BYTES_UUID_DICT + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctNativeUuidRaw() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + UUID_RAW + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctNativeUuidDict() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + UUID_DICT + ") FROM " + TABLE_NAME);
+  }
+
+  // ---- Equality filter (full scan) ------------------------------------
+  // For BYTES, the literal is a lowercase hex string (no dashes).
+  // For STRING and UUID, the literal is the RFC 4122 dash-separated string.
+
+  @Benchmark
+  public BrokerResponseNative filterStrUuidRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + STR_UUID_RAW + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterStrUuidDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + STR_UUID_DICT + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterBytesUuidRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + BYTES_UUID_RAW + " = '" + _filterBytesHex + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterBytesUuidDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + BYTES_UUID_DICT + " = '" + _filterBytesHex + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterNativeUuidRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + UUID_RAW + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterNativeUuidDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + UUID_DICT + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterTwoLongRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + LONG_MSB_RAW + " = " + _filterMsb
+            + " AND " + LONG_LSB_RAW + " = " + _filterLsb);
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterTwoLongDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + LONG_MSB_DICT + " = " + _filterMsb
+            + " AND " + LONG_LSB_DICT + " = " + _filterLsb);
+  }
+
+  @Override
+  protected String getFilter() {
+    return null;
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkUuidQueryExecution.class.getSimpleName()).build()).run();
+  }
+}


### PR DESCRIPTION
## What
End-to-end verification and documentation.

## Changes
- `UuidTypeTest`, `UuidTypeRealtimeTest`, `UuidUpsertRealtimeTest` (extend `CustomDataQueryClusterIntegrationTest`)
- JMH `BenchmarkUuidGroupingAndLookup`, `BenchmarkUuidQueryExecution`
- `README` usage / limitations / migration

## Enables
Offline + realtime + upsert integration coverage and performance benchmarks for the whole feature.

## Depends on
PRs 1, 3 and 6 (benchmarks import multi-stage runtime classes).

## Why this PR exists
This is **part 8 of 8** splitting [apache/pinot#18140](https://github.com/apache/pinot/pull/18140) (first-class logical `UUID` type) into reviewable, layered PRs, as requested on that PR.

The split is enabled by the v1 design: `DataType.UUID` has **stored type `BYTES`**, so most code paths handle it automatically; each PR adds explicit UUID semantics to one subsystem.

This PR is **stacked on `07-udfs-partitioning`** (its base branch), so the diff shown here is **only this layer**.

### Full stack (base → top)
1. `uuid-split/01-spi-foundation` — Add logical UUID type foundation (pinot-spi)
2. `uuid-split/02-ingest-storage` — UUID ingest and segment storage
3. `uuid-split/03-result-rendering` — UUID result rendering (DataSchema, Arrow/JSON encoders)
4. `uuid-split/04-sse-predicates-cast` — UUID server-side predicates, CAST and transforms
5. `uuid-split/05-agg-groupby-distinct` — UUID aggregation, group-by and distinct
6. `uuid-split/06-mse-planner-runtime` — UUID multi-stage engine (planner + runtime)
7. `uuid-split/07-udfs-partitioning` — UUID scalar UDFs and partitioning
8. `uuid-split/08-it-bench-docs` — UUID integration tests, benchmarks and docs

Full feature description, v1 design contract, scope exclusions, and benchmark numbers: [apache/pinot#18140](https://github.com/apache/pinot/pull/18140).
