### PR TITLE
Fix VARIANT opacity guards (OBJECT regression) and effective partial-upsert validation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -108,8 +108,9 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     _rightTransformFunction = arguments.get(1);
     DataType leftDataType = _leftTransformFunction.getResultMetadata().getDataType();
     DataType rightDataType = _rightTransformFunction.getResultMetadata().getDataType();
-    Preconditions.checkArgument((leftDataType == DataType.UNKNOWN || leftDataType.supportsOrdering())
-            && (rightDataType == DataType.UNKNOWN || rightDataType.supportsOrdering()),
+    // Reject raw VARIANT operands only; other types keep their existing comparison behavior. VARIANT is opaque
+    // because its PVAR byte encoding is not a canonical semantic ordering.
+    Preconditions.checkArgument(leftDataType != DataType.VARIANT && rightDataType != DataType.VARIANT,
         "Raw VARIANT values do not support comparison; extract a typed path with variantGet first");
     if (leftDataType == DataType.UNKNOWN || rightDataType == DataType.UNKNOWN) {
       _alwaysNull = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
@@ -65,8 +65,9 @@ public class InTransformFunction extends BaseTransformFunction {
         + "transform function: (expression, values)", getName());
     _mainFunction = arguments.get(0);
     for (TransformFunction argument : arguments) {
+      // Reject raw VARIANT operands only; preserve existing IN behavior for all other types.
       DataType dataType = argument.getResultMetadata().getDataType();
-      Preconditions.checkArgument(dataType.supportsEquality() && dataType.supportsHashing(),
+      Preconditions.checkArgument(dataType != DataType.VARIANT,
           "Raw VARIANT values do not support IN; extract a typed path with variantGet first");
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
@@ -51,9 +52,11 @@ public class OrderByComparatorFactory {
         throw new BadQueryRequestException("MV expression: " + orderByExpressions.get(i)
             + " should not be included in the ORDER-BY clause");
       }
-      if (!orderByColumnContexts[i].getDataType().supportsOrdering()) {
-        throw new BadQueryRequestException(
-            "ORDER BY does not support raw VARIANT values; extract a typed path with variantGet first");
+      FieldSpec.DataType dataType = orderByColumnContexts[i].getDataType();
+      if (!dataType.supportsOrdering()) {
+        throw new BadQueryRequestException(dataType == FieldSpec.DataType.VARIANT
+            ? "ORDER BY does not support raw VARIANT values; extract a typed path with variantGet first"
+            : "ORDER BY does not support " + dataType + " values");
       }
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/validation/VariantTypeValidationVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/validation/VariantTypeValidationVisitor.java
@@ -61,6 +61,12 @@ public final class VariantTypeValidationVisitor extends PlanNodeVisitor.DepthFir
   /// <p>This method is also invoked by the runtime as a defensive check for plans that did not pass through the
   /// current broker planner.
   public static void validateAggregateInputs(AggregateNode node, DataSchema inputSchema) {
+    for (int key : node.getGroupKeys()) {
+      DataSchema.ColumnDataType dataType = inputSchema.getColumnDataType(key);
+      if (!dataType.supportsEquality() || !dataType.supportsHashing()) {
+        throw unsupported("GROUP BY", dataType);
+      }
+    }
     validateAggregateInputs(node.getAggCalls(), inputSchema);
   }
 
@@ -71,8 +77,9 @@ public final class VariantTypeValidationVisitor extends PlanNodeVisitor.DepthFir
         continue;
       }
       for (RexExpression operand : aggCall.getFunctionOperands()) {
-        if (!getLogicalType(operand, inputSchema).supportsDirectAggregation()) {
-          throw unsupported("Aggregate function " + aggCall.getFunctionName());
+        DataSchema.ColumnDataType dataType = getLogicalType(operand, inputSchema);
+        if (!dataType.supportsDirectAggregation()) {
+          throw unsupported("Aggregate function " + aggCall.getFunctionName(), dataType);
         }
       }
     }
@@ -93,8 +100,9 @@ public final class VariantTypeValidationVisitor extends PlanNodeVisitor.DepthFir
     DataSchema dataSchema = node.getDataSchema();
     for (RelFieldCollation collation : node.getCollations()) {
       int fieldIndex = collation.getFieldIndex();
-      if (!dataSchema.getColumnDataType(fieldIndex).supportsOrdering()) {
-        throw unsupported("ORDER BY");
+      DataSchema.ColumnDataType dataType = dataSchema.getColumnDataType(fieldIndex);
+      if (!dataType.supportsOrdering()) {
+        throw unsupported("ORDER BY", dataType);
       }
     }
     return super.visitSort(node, context);
@@ -105,7 +113,7 @@ public final class VariantTypeValidationVisitor extends PlanNodeVisitor.DepthFir
     if (!(node.getSetOpType() == SetOpNode.SetOpType.UNION && node.isAll())) {
       for (DataSchema.ColumnDataType dataType : node.getDataSchema().getColumnDataTypes()) {
         if (!dataType.supportsEquality() || !dataType.supportsHashing()) {
-          throw unsupported(node.explain().replace('_', ' '));
+          throw unsupported(node.explain().replace('_', ' '), dataType);
         }
       }
     }
@@ -150,12 +158,13 @@ public final class VariantTypeValidationVisitor extends PlanNodeVisitor.DepthFir
     for (int key : node.getKeys()) {
       DataSchema.ColumnDataType dataType = inputSchema.getColumnDataType(key);
       if (!dataType.supportsEquality() || !dataType.supportsHashing()) {
-        throw unsupported("Window PARTITION BY");
+        throw unsupported("Window PARTITION BY", dataType);
       }
     }
     for (RelFieldCollation collation : node.getCollations()) {
-      if (!inputSchema.getColumnDataType(collation.getFieldIndex()).supportsOrdering()) {
-        throw unsupported("Window ORDER BY");
+      DataSchema.ColumnDataType dataType = inputSchema.getColumnDataType(collation.getFieldIndex());
+      if (!dataType.supportsOrdering()) {
+        throw unsupported("Window ORDER BY", dataType);
       }
     }
     validateAggregateInputs(node.getAggCalls(), inputSchema);
@@ -178,8 +187,12 @@ public final class VariantTypeValidationVisitor extends PlanNodeVisitor.DepthFir
     throw new IllegalStateException("Unsupported aggregate operand: " + expression.getClass().getName());
   }
 
-  private static QueryException unsupported(String operation) {
-    return new QueryException(QueryErrorCode.QUERY_PLANNING,
-        operation + " does not support raw VARIANT values; extract a typed path with variantGet first");
+  private static QueryException unsupported(String operation, DataSchema.ColumnDataType dataType) {
+    // Name the actual unsupported type so the error is accurate for non-VARIANT opaque types (OBJECT, arrays, MAP),
+    // while preserving the raw-VARIANT wording and remediation guidance for the VARIANT case.
+    String message = dataType == DataSchema.ColumnDataType.VARIANT
+        ? operation + " does not support raw VARIANT values; extract a typed path with variantGet first"
+        : operation + " does not support " + dataType + " values";
+    return new QueryException(QueryErrorCode.QUERY_PLANNING, message);
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/validation/VariantTypeValidationVisitorTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/validation/VariantTypeValidationVisitorTest.java
@@ -142,6 +142,16 @@ public class VariantTypeValidationVisitorTest {
   }
 
   @Test
+  public void testRejectsRawVariantGroupByKey() {
+    // COUNT is raw-variant-independent, so the rejection must come from the VARIANT GROUP BY key itself.
+    AggregateNode node = aggregateGroupBy("COUNT", VARIANT_SCHEMA, List.of(0));
+    QueryException exception =
+        Assert.expectThrows(QueryException.class, () -> node.visit(VariantTypeValidationVisitor.INSTANCE, null));
+    Assert.assertTrue(exception.getMessage().contains("GROUP BY"));
+    Assert.assertTrue(exception.getMessage().contains("raw VARIANT"));
+  }
+
+  @Test
   public void testUsesLogicalTypeInsteadOfVariantStorageType() {
     DataSchema bytesSchema =
         new DataSchema(new String[]{"bytes"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BYTES});
@@ -223,6 +233,15 @@ public class VariantTypeValidationVisitorTest {
         new DataSchema(new String[]{"result"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     return new AggregateNode(0, resultSchema, PlanNode.NodeHint.EMPTY, List.of(input), List.of(aggCall), List.of(-1),
         List.of(), AggregateNode.AggType.DIRECT, false, List.of(), 0);
+  }
+
+  private static AggregateNode aggregateGroupBy(String functionName, DataSchema inputSchema, List<Integer> groupKeys) {
+    ValueNode input = new ValueNode(0, inputSchema, PlanNode.NodeHint.EMPTY, List.of(), List.of());
+    RexExpression.FunctionCall aggCall = functionCall(functionName, false, new RexExpression.InputRef(0));
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"result"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
+    return new AggregateNode(0, resultSchema, PlanNode.NodeHint.EMPTY, List.of(input), List.of(aggCall), List.of(-1),
+        groupKeys, AggregateNode.AggType.DIRECT, false, List.of(), 0);
   }
 
   private static WindowNode window(String functionName) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -28,6 +28,7 @@ import java.util.PriorityQueue;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.planner.plannode.SortNode;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
@@ -75,9 +76,10 @@ public class SortOperator extends MultiStageOperator {
     // - Input is already sorted
     List<RelFieldCollation> collations = node.getCollations();
     for (RelFieldCollation collation : collations) {
-      Preconditions.checkArgument(
-          _dataSchema.getColumnDataType(collation.getFieldIndex()).supportsOrdering(),
-          "ORDER BY does not support raw VARIANT values; extract a typed path with variantGet first");
+      ColumnDataType dataType = _dataSchema.getColumnDataType(collation.getFieldIndex());
+      Preconditions.checkArgument(dataType.supportsOrdering(), dataType == ColumnDataType.VARIANT
+          ? "ORDER BY does not support raw VARIANT values; extract a typed path with variantGet first"
+          : "ORDER BY does not support " + dataType + " values");
     }
     if (collations.isEmpty() || input instanceof SortedMailboxReceiveOperator) {
       _priorityQueue = null;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
@@ -57,9 +57,10 @@ public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
     _dataSchema = node.getDataSchema();
     _collations = node.getCollations();
     for (RelFieldCollation collation : _collations) {
-      Preconditions.checkArgument(
-          _dataSchema.getColumnDataType(collation.getFieldIndex()).supportsOrdering(),
-          "ORDER BY does not support raw VARIANT values; extract a typed path with variantGet first");
+      DataSchema.ColumnDataType dataType = _dataSchema.getColumnDataType(collation.getFieldIndex());
+      Preconditions.checkArgument(dataType.supportsOrdering(), dataType == DataSchema.ColumnDataType.VARIANT
+          ? "ORDER BY does not support raw VARIANT values; extract a typed path with variantGet first"
+          : "ORDER BY does not support " + dataType + " values");
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
@@ -116,7 +116,8 @@ public abstract class FilterOperand implements TransformOperand {
       _childOperands = new ArrayList<>(children.size());
       for (RexExpression child : children) {
         TransformOperand operand = TransformOperandFactory.getTransformOperand(child, dataSchema);
-        Preconditions.checkArgument(operand.getResultType().supportsEquality(),
+        // Reject raw VARIANT operands only; preserve existing IN behavior for all other types.
+        Preconditions.checkArgument(operand.getResultType() != ColumnDataType.VARIANT,
             "Raw VARIANT values do not support IN; extract a typed path with variantGet first");
         _childOperands.add(operand);
       }
@@ -196,8 +197,10 @@ public abstract class FilterOperand implements TransformOperand {
 
       ColumnDataType lhsType = _lhs.getResultType();
       ColumnDataType rhsType = _rhs.getResultType();
-      Preconditions.checkArgument((lhsType == ColumnDataType.UNKNOWN || lhsType.supportsOrdering())
-              && (rhsType == ColumnDataType.UNKNOWN || rhsType.supportsOrdering()),
+      // Reject raw VARIANT operands only; other non-orderable types (OBJECT, arrays, MAP) keep their existing
+      // best-effort comparison behavior. VARIANT is opaque because its PVAR byte encoding is not a canonical
+      // semantic ordering, so a comparison must extract a typed scalar first.
+      Preconditions.checkArgument(lhsType != ColumnDataType.VARIANT && rhsType != ColumnDataType.VARIANT,
           "Raw VARIANT values do not support comparison; extract a typed path with variantGet first");
       if (lhsType == ColumnDataType.UNKNOWN || rhsType == ColumnDataType.UNKNOWN || lhsType == rhsType) {
         _requireCasting = false;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperandFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperandFactory.java
@@ -62,7 +62,8 @@ public class TransformOperandFactory {
       Preconditions.checkState(numOperands == 2, "%s takes 2 arguments, got: %s", functionCall.getFunctionName(),
           numOperands);
       for (RexExpression operand : operands) {
-        Preconditions.checkArgument(getResultType(operand, dataSchema).supportsEquality(),
+        // Reject raw VARIANT operands only; preserve existing distinct-from behavior for all other types.
+        Preconditions.checkArgument(getResultType(operand, dataSchema) != DataSchema.ColumnDataType.VARIANT,
             "Raw VARIANT values do not support comparison; extract a typed path with variantGet first");
       }
       return new FunctionOperand(functionCall, dataSchema);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/operands/FilterOperandTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/operands/FilterOperandTest.java
@@ -31,6 +31,8 @@ public class FilterOperandTest {
       new DataSchema(new String[]{"value"}, new ColumnDataType[]{ColumnDataType.INT});
   private static final DataSchema VARIANT_SCHEMA =
       new DataSchema(new String[]{"payload"}, new ColumnDataType[]{ColumnDataType.VARIANT});
+  private static final DataSchema OBJECT_SCHEMA =
+      new DataSchema(new String[]{"payload"}, new ColumnDataType[]{ColumnDataType.OBJECT});
   private static final RexExpression NULL_LITERAL = new RexExpression.Literal(ColumnDataType.UNKNOWN, null);
   private static final List<RexExpression> VARIANT_OPERANDS =
       List.of(new RexExpression.InputRef(0), new RexExpression.InputRef(0));
@@ -68,6 +70,19 @@ public class FilterOperandTest {
         Assert.expectThrows(IllegalArgumentException.class,
             () -> new FilterOperand.In(VARIANT_OPERANDS, VARIANT_SCHEMA, true));
     Assert.assertTrue(exception.getMessage().contains("Raw VARIANT values do not support IN"));
+  }
+
+  @Test
+  public void testNonVariantOpaqueTypesAreNotRejectedAsVariant() {
+    // OBJECT (and other non-orderable types) must keep their existing best-effort comparison/IN behavior rather
+    // than being rejected with the VARIANT-specific guard. Constructing the operands must not throw.
+    new FilterOperand.Predicate(VARIANT_OPERANDS, OBJECT_SCHEMA, value -> value == 0);
+    new FilterOperand.In(VARIANT_OPERANDS, OBJECT_SCHEMA, false);
+    for (String functionName : List.of("IS_DISTINCT_FROM", "isNotDistinctFrom")) {
+      RexExpression.FunctionCall functionCall =
+          new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, functionName, VARIANT_OPERANDS);
+      TransformOperandFactory.getTransformOperand(functionCall, OBJECT_SCHEMA);
+    }
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1433,6 +1433,25 @@ public final class TableConfigUtils {
     Map<String, UpsertConfig.Strategy> partialUpsertStrategies = upsertConfig.getPartialUpsertStrategies();
     String partialUpsertMergerClass = upsertConfig.getPartialUpsertMergerClass();
 
+    // VARIANT columns support only the OVERWRITE partial-upsert strategy. A column that is not listed in
+    // partialUpsertStrategies is merged at runtime with defaultPartialUpsertStrategy, so validating only the listed
+    // entries would let a non-OVERWRITE default (or a custom merger class) silently apply INCREMENT/APPEND/UNION/IGNORE
+    // to a VARIANT byte envelope. Validate the effective strategy for every VARIANT column here.
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (fieldSpec.getDataType() != DataType.VARIANT) {
+        continue;
+      }
+      String column = fieldSpec.getName();
+      Preconditions.checkState(StringUtils.isBlank(partialUpsertMergerClass),
+          "VARIANT column supports only OVERWRITE partial-upsert strategy and cannot be merged by a custom "
+              + "partialUpsertMergerClass: %s", column);
+      UpsertConfig.Strategy effectiveStrategy =
+          partialUpsertStrategies != null && partialUpsertStrategies.containsKey(column)
+              ? partialUpsertStrategies.get(column) : upsertConfig.getDefaultPartialUpsertStrategy();
+      Preconditions.checkState(effectiveStrategy == UpsertConfig.Strategy.OVERWRITE,
+          "VARIANT column supports only OVERWRITE partial-upsert strategy: %s", column);
+    }
+
     // check if partialUpsertMergerClass is provided then partialUpsertStrategies should be empty
     if (StringUtils.isNotBlank(partialUpsertMergerClass)) {
       Preconditions.checkState(MapUtils.isEmpty(partialUpsertStrategies),
@@ -1456,10 +1475,7 @@ public final class TableConfigUtils {
 
         FieldSpec fieldSpec = schema.getFieldSpecFor(column);
         Preconditions.checkState(fieldSpec != null, "Merger cannot be applied to non-existing column: %s", column);
-        if (fieldSpec.getDataType() == DataType.VARIANT) {
-          Preconditions.checkState(columnStrategy == UpsertConfig.Strategy.OVERWRITE,
-              "VARIANT column supports only OVERWRITE partial-upsert strategy: %s", column);
-        }
+        // VARIANT columns are validated up front against their effective strategy (default or explicit).
 
         if (columnStrategy == UpsertConfig.Strategy.INCREMENT) {
           Preconditions.checkState(fieldSpec.getDataType().getStoredType().isNumeric(),

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/VariantTableConfigValidationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/VariantTableConfigValidationTest.java
@@ -227,6 +227,63 @@ public class VariantTableConfigValidationTest {
   }
 
   @Test
+  public void testNonOverwriteDefaultPartialUpsertStrategyIsRejectedForUnlistedVariant() {
+    // The VARIANT column is not listed in partialUpsertStrategies, so at merge time it uses
+    // defaultPartialUpsertStrategy. A non-OVERWRITE default must still be rejected.
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setComparisonColumn(ID_COLUMN);
+    upsertConfig.setPartialUpsertStrategies(Map.of(ID_COLUMN, UpsertConfig.Strategy.OVERWRITE));
+    upsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.UNION);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setNullHandlingEnabled(true)
+        .setUpsertConfig(upsertConfig)
+        .build();
+    try {
+      TableConfigUtils.validatePartialUpsertStrategies(tableConfig, UPSERT_SCHEMA);
+      fail("Expected non-OVERWRITE default VARIANT partial-upsert strategy validation to fail");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage() != null
+              && e.getMessage().contains("VARIANT column supports only OVERWRITE partial-upsert strategy"),
+          "Unexpected validation error: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDefaultOverwritePartialUpsertStrategyIsValidForUnlistedVariant() {
+    // The VARIANT column is unlisted and defaultPartialUpsertStrategy defaults to OVERWRITE, which is valid.
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setComparisonColumn(ID_COLUMN);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setNullHandlingEnabled(true)
+        .setUpsertConfig(upsertConfig)
+        .build();
+    TableConfigUtils.validatePartialUpsertStrategies(tableConfig, UPSERT_SCHEMA);
+  }
+
+  @Test
+  public void testCustomPartialUpsertMergerIsRejectedForVariant() {
+    // A custom merger class cannot be validated against the OVERWRITE-only VARIANT contract, so it must be rejected.
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setComparisonColumn(ID_COLUMN);
+    upsertConfig.setPartialUpsertMergerClass("com.example.CustomMerger");
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setNullHandlingEnabled(true)
+        .setUpsertConfig(upsertConfig)
+        .build();
+    try {
+      TableConfigUtils.validatePartialUpsertStrategies(tableConfig, UPSERT_SCHEMA);
+      fail("Expected custom partialUpsertMergerClass with a VARIANT column to fail");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage() != null && e.getMessage().contains("custom")
+              && e.getMessage().contains("VARIANT column supports only OVERWRITE partial-upsert strategy"),
+          "Unexpected validation error: " + e.getMessage());
+    }
+  }
+
+  @Test
   public void testMetricsAggregationAndDefaultStarTreeAreRejected() {
     TableConfig aggregateMetricsTable = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME)


### PR DESCRIPTION
Addresses the two Medium review findings on #19101.

## 1. OBJECT-comparison regression (review finding #1)
The VARIANT opacity guards used `supportsOrdering()`/`supportsEquality()`, which are also false for OBJECT, arrays, and MAP. This narrowed existing behavior: an `OBJECT = OBJECT` comparison (previously handled by the best-effort path documented in `FilterOperand.Predicate`'s Javadoc) now threw a VARIANT-specific error. The same guard was added to the single-stage engine too.

Changed to reject **only** raw VARIANT in:
- `FilterOperand` (Predicate, In) and `TransformOperandFactory` (IS_DISTINCT_FROM) — multi-stage
- `BinaryOperatorTransformFunction`, `InTransformFunction` — single-stage

The UNKNOWN → `_alwaysNull` null-handling path in `BinaryOperatorTransformFunction` is preserved. Added `FilterOperandTest.testNonVariantOpaqueTypesAreNotRejectedAsVariant`.

## 2. Effective partial-upsert strategy validation (review finding #2)
The VARIANT OVERWRITE-only check only iterated columns listed in `partialUpsertStrategies`. An unlisted VARIANT column is merged at runtime with `defaultPartialUpsertStrategy` (and a custom `partialUpsertMergerClass` applies arbitrary logic), so a non-OVERWRITE default could silently run INCREMENT/APPEND/UNION/IGNORE against a VARIANT byte envelope. `TableConfigUtils` now validates the effective strategy for every VARIANT column and rejects a custom merger on VARIANT columns. Added 3 tests.

## Verification (JDK 25)
- `VariantTableConfigValidationTest`: 17 passed
- `FilterOperandTest`: 6 passed
- pinot-core Equals/NotEquals/GreaterThan/LessThan/GtE/LtE/InTransformFunctionTest: 85 passed
- spotless + checkstyle clean on all 3 modules