### PR TITLE
[CI] Parallelize unit-test phase with fork-safe port/temp-dir isolation

### DIFF
--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -30,19 +30,20 @@ netstat -i
 #     due to the -am flag (include dependency modules)
 #
 # Parallelism / memory:
-#   - UNIT_TEST_FORK_COUNT (default 2) sets surefire forkCount so test *classes* run in
+#   - UNIT_TEST_FORK_COUNT (default 3) sets surefire forkCount so test *classes* run in
 #     separate parallel JVMs (reuseForks=false keeps one class per JVM). This is
 #     process-level isolation, not TestNG intra-JVM threading, so tests that were unsafe
 #     to run multi-threaded within a single JVM (e.g. pinot-plugins) are unaffected.
 #     Cross-fork resource collisions (ZK/controller ports, temp dirs) are avoided by
 #     offsetting per surefire.forkNumber; embedded Kafka clusters use ephemeral ports.
-#     This is the main lever for shortening the unit-test phase.
-#   - UNIT_TEST_FORK_HEAP (default 3g) caps per-fork heap so N forks fit in the
+#     This is the main lever for shortening the unit-test phase. 3 forks on the 4-vCPU
+#     runner keeps a core free for the Maven reactor / GC while test JVMs spend much of
+#     their time blocked on ZK/Helix/socket startup, so the extra fork still pays off.
+#   - UNIT_TEST_FORK_HEAP (default 2500m) caps per-fork heap so N forks fit in the
 #     runner's memory (N * heap + the mvn JVM must stay under the runner's RAM).
-UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-2}"
-# 3g/fork: 2 forks * 3g + the 2g Maven JVM stays well under the runner's 16g while leaving
-# heap headroom for memory-heavy modules (e.g. pinot-segment-local) that previously had 4g.
-UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-3g}"
+UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-3}"
+# 2500m/fork: 3 forks * 2500m + the 2g Maven JVM (~9.5g) stays well under the runner's 16g.
+UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-2500m}"
 FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP}"
 if [ "$RUN_TEST_SET" == "1" ]; then
   mvn test ${FORK_OPTS} \

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -26,8 +26,8 @@ ifconfig
 netstat -i
 
 # Unit Tests
-#   - TEST_SET#1 runs install and test together so the module list must ensure no additional modules were tested
-#     due to the -am flag (include dependency modules)
+#   - Both test sets run plain `mvn test` (no install, no -am): the modules were already built
+#     and installed by .pinot_tests_build.sh, so only the modules listed here are tested.
 #
 # Parallelism / memory:
 #   - UNIT_TEST_FORK_COUNT (default 3) sets surefire forkCount so test *classes* run in
@@ -44,13 +44,21 @@ netstat -i
 UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-3}"
 # 2500m/fork: 3 forks * 2500m + the 2g Maven JVM (~9.5g) stays well under the runner's 16g.
 UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-2500m}"
-FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP}"
+# Fork-scope the JaCoCo exec file (jacoco-<forkNumber>.exec) so parallel forks don't append to
+# one shared jacoco.exec and corrupt coverage. Only the unit lane sets this; other lanes keep
+# the default empty suffix (target/jacoco.exec).
+FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP} -Djacoco.exec.suffix=-\${surefire.forkNumber}"
 if [ "$RUN_TEST_SET" == "1" ]; then
+  # pinot-segment-local's tests run here (not in set #2) to balance the two shards: it is the
+  # largest single test module and is already built in set #1 (see .pinot_tests_build.sh), so
+  # moving its tests off the slower set #2 (which has a ~3x longer build) keeps both shards
+  # near-equal in total wall-clock. No -am on this command, so only the listed modules test.
   mvn test ${FORK_OPTS} \
       -pl 'pinot-spi' \
       -pl 'pinot-segment-spi' \
       -pl 'pinot-common' \
       -pl ':pinot-yammer' \
+      -pl 'pinot-segment-local' \
       -pl 'pinot-core' \
       -pl 'pinot-query-planner' \
       -pl 'pinot-query-runtime' \
@@ -61,6 +69,7 @@ if [ "$RUN_TEST_SET" == "2" ]; then
     -pl '!pinot-spi' \
     -pl '!pinot-segment-spi' \
     -pl '!pinot-common' \
+    -pl '!pinot-segment-local' \
     -pl '!pinot-core' \
     -pl '!pinot-query-planner' \
     -pl '!pinot-query-runtime' \

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -41,13 +41,15 @@ netstat -i
 #     their time blocked on ZK/Helix/socket startup, so the extra fork still pays off.
 #   - UNIT_TEST_FORK_HEAP (default 2500m) caps per-fork heap so N forks fit in the
 #     runner's memory (N * heap + the mvn JVM must stay under the runner's RAM).
-#   - UNIT_TEST_RERUN_COUNT (default 2) retries a failing test before failing the build, to
-#     absorb a few pre-existing load-sensitive flaky tests exposed by parallel forks. Surefire
-#     reports a test that only passes on retry as flaky, so real failures still fail the build.
+#   - UNIT_TEST_RERUN_COUNT (default 0) retries a failing test before failing the build. Left at 0
+#     because the load-sensitive flaky tests parallel forks exposed are fixed at the root cause
+#     (SegmentPreProcessorTest mtime granularity, LuceneMutableTextIndexTest NRT-refresh wait). It
+#     remains overridable as an escape hatch if a new flake appears, but is intentionally not a
+#     standing default so real failures are never masked.
 UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-3}"
 # 2500m/fork: 3 forks * 2500m + the 2g Maven JVM (~9.5g) stays well under the runner's 16g.
 UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-2500m}"
-UNIT_TEST_RERUN_COUNT="${UNIT_TEST_RERUN_COUNT:-2}"
+UNIT_TEST_RERUN_COUNT="${UNIT_TEST_RERUN_COUNT:-0}"
 # Coverage adds ~30% to the test phase (JaCoCo agent per fork + aggregate report). Keep it on by
 # default to preserve Codecov behavior; set RUN_CODECOVERAGE=false (e.g. on PRs) to trade coverage
 # for a faster run.

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -41,13 +41,17 @@ netstat -i
 #     their time blocked on ZK/Helix/socket startup, so the extra fork still pays off.
 #   - UNIT_TEST_FORK_HEAP (default 2500m) caps per-fork heap so N forks fit in the
 #     runner's memory (N * heap + the mvn JVM must stay under the runner's RAM).
+#   - UNIT_TEST_RERUN_COUNT (default 2) retries a failing test before failing the build, to
+#     absorb a few pre-existing load-sensitive flaky tests exposed by parallel forks. Surefire
+#     reports a test that only passes on retry as flaky, so real failures still fail the build.
 UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-3}"
 # 2500m/fork: 3 forks * 2500m + the 2g Maven JVM (~9.5g) stays well under the runner's 16g.
 UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-2500m}"
+UNIT_TEST_RERUN_COUNT="${UNIT_TEST_RERUN_COUNT:-2}"
 # Fork-scope the JaCoCo exec file (jacoco-<forkNumber>.exec) so parallel forks don't append to
 # one shared jacoco.exec and corrupt coverage. Only the unit lane sets this; other lanes keep
 # the default empty suffix (target/jacoco.exec).
-FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP} -Djacoco.exec.suffix=-\${surefire.forkNumber}"
+FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP} -Dunit.test.rerun.count=${UNIT_TEST_RERUN_COUNT} -Djacoco.exec.suffix=-\${surefire.forkNumber}"
 if [ "$RUN_TEST_SET" == "1" ]; then
   # pinot-segment-local's tests run here (not in set #2) to balance the two shards: it is the
   # largest single test module and is already built in set #1 (see .pinot_tests_build.sh), so

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -48,10 +48,19 @@ UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-3}"
 # 2500m/fork: 3 forks * 2500m + the 2g Maven JVM (~9.5g) stays well under the runner's 16g.
 UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-2500m}"
 UNIT_TEST_RERUN_COUNT="${UNIT_TEST_RERUN_COUNT:-2}"
+# Coverage adds ~30% to the test phase (JaCoCo agent per fork + aggregate report). Keep it on by
+# default to preserve Codecov behavior; set RUN_CODECOVERAGE=false (e.g. on PRs) to trade coverage
+# for a faster run.
+RUN_CODECOVERAGE="${RUN_CODECOVERAGE:-true}"
 # Fork-scope the JaCoCo exec file (jacoco-<forkNumber>.exec) so parallel forks don't append to
 # one shared jacoco.exec and corrupt coverage. Only the unit lane sets this; other lanes keep
 # the default empty suffix (target/jacoco.exec).
 FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP} -Dunit.test.rerun.count=${UNIT_TEST_RERUN_COUNT} -Djacoco.exec.suffix=-\${surefire.forkNumber}"
+if [ "$RUN_CODECOVERAGE" == "true" ]; then
+  COVERAGE_PROFILE=",codecoverage"
+else
+  COVERAGE_PROFILE=""
+fi
 if [ "$RUN_TEST_SET" == "1" ]; then
   # pinot-segment-local's tests run here (not in set #2) to balance the two shards: it is the
   # largest single test module and is already built in set #1 (see .pinot_tests_build.sh), so
@@ -66,7 +75,7 @@ if [ "$RUN_TEST_SET" == "1" ]; then
       -pl 'pinot-core' \
       -pl 'pinot-query-planner' \
       -pl 'pinot-query-runtime' \
-      -P github-actions,codecoverage,no-integration-tests || exit 1
+      -P github-actions,no-integration-tests${COVERAGE_PROFILE} || exit 1
 fi
 if [ "$RUN_TEST_SET" == "2" ]; then
   mvn test ${FORK_OPTS} \
@@ -78,10 +87,13 @@ if [ "$RUN_TEST_SET" == "2" ]; then
     -pl '!pinot-query-planner' \
     -pl '!pinot-query-runtime' \
     -pl '!:pinot-yammer' \
-    -P github-actions,codecoverage,no-integration-tests || exit 1
+    -P github-actions,no-integration-tests${COVERAGE_PROFILE} || exit 1
 fi
 
 # Aggregate coverage across all per-fork exec files (jacoco-*.exec) written under forkCount>1,
-# while still matching the single-fork jacoco.exec produced by non-parallel runs.
-mvn jacoco:report-aggregate@report -P codecoverage \
-  -Djacoco.dataFileIncludes='**/target/jacoco-*.exec,**/target/jacoco.exec' || exit 1
+# while still matching the single-fork jacoco.exec produced by non-parallel runs. Skipped when
+# coverage is disabled.
+if [ "$RUN_CODECOVERAGE" == "true" ]; then
+  mvn jacoco:report-aggregate@report -P codecoverage \
+    -Djacoco.dataFileIncludes='**/target/jacoco-*.exec,**/target/jacoco.exec' || exit 1
+fi

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -28,9 +28,24 @@ netstat -i
 # Unit Tests
 #   - TEST_SET#1 runs install and test together so the module list must ensure no additional modules were tested
 #     due to the -am flag (include dependency modules)
-#   - tests for pinot-plugins should not be ran multi-threaded
+#
+# Parallelism / memory:
+#   - UNIT_TEST_FORK_COUNT (default 2) sets surefire forkCount so test *classes* run in
+#     separate parallel JVMs (reuseForks=false keeps one class per JVM). This is
+#     process-level isolation, not TestNG intra-JVM threading, so tests that were unsafe
+#     to run multi-threaded within a single JVM (e.g. pinot-plugins) are unaffected.
+#     Cross-fork resource collisions (ZK/controller ports, temp dirs) are avoided by
+#     offsetting per surefire.forkNumber; embedded Kafka clusters use ephemeral ports.
+#     This is the main lever for shortening the unit-test phase.
+#   - UNIT_TEST_FORK_HEAP (default 3g) caps per-fork heap so N forks fit in the
+#     runner's memory (N * heap + the mvn JVM must stay under the runner's RAM).
+UNIT_TEST_FORK_COUNT="${UNIT_TEST_FORK_COUNT:-2}"
+# 3g/fork: 2 forks * 3g + the 2g Maven JVM stays well under the runner's 16g while leaving
+# heap headroom for memory-heavy modules (e.g. pinot-segment-local) that previously had 4g.
+UNIT_TEST_FORK_HEAP="${UNIT_TEST_FORK_HEAP:-3g}"
+FORK_OPTS="-Dunit.test.fork.count=${UNIT_TEST_FORK_COUNT} -Dunit.test.fork.heap=${UNIT_TEST_FORK_HEAP}"
 if [ "$RUN_TEST_SET" == "1" ]; then
-  mvn test \
+  mvn test ${FORK_OPTS} \
       -pl 'pinot-spi' \
       -pl 'pinot-segment-spi' \
       -pl 'pinot-common' \
@@ -41,7 +56,7 @@ if [ "$RUN_TEST_SET" == "1" ]; then
       -P github-actions,codecoverage,no-integration-tests || exit 1
 fi
 if [ "$RUN_TEST_SET" == "2" ]; then
-  mvn test \
+  mvn test ${FORK_OPTS} \
     -pl '!pinot-spi' \
     -pl '!pinot-segment-spi' \
     -pl '!pinot-common' \
@@ -52,4 +67,7 @@ if [ "$RUN_TEST_SET" == "2" ]; then
     -P github-actions,codecoverage,no-integration-tests || exit 1
 fi
 
-mvn jacoco:report-aggregate@report -P codecoverage || exit 1
+# Aggregate coverage across all per-fork exec files (jacoco-*.exec) written under forkCount>1,
+# while still matching the single-fork jacoco.exec produced by non-parallel runs.
+mvn jacoco:report-aggregate@report -P codecoverage \
+  -Djacoco.dataFileIncludes='**/target/jacoco-*.exec,**/target/jacoco.exec' || exit 1

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
@@ -45,8 +45,14 @@ public class ZkStarter {
 
   /// Per-fork offset applied to the default test port so that concurrent surefire forks
   /// (forkCount > 1, reuseForks=false) do not scan from the same base port and collide.
-  /// surefire injects `surefire.forkNumber` (1-based) into each fork; it is absent (0) for
-  /// single-fork/local runs, preserving the historical default of {@link #DEFAULT_ZK_TEST_PORT}.
+  ///
+  /// This is purely a test-harness hook: the offset is derived from the `surefire.forkNumber`
+  /// system property, which surefire injects only inside a forked test JVM (1-based, so it is 1
+  /// even at forkCount=1, and 1..N under parallel forks). In any production process that property
+  /// is absent, so `forkNumber()` returns 0 and the no-arg {@link #startLocalZkServer()} scans
+  /// from the historical {@link #DEFAULT_ZK_TEST_PORT}. Under tests each fork scans from a distinct
+  /// base ({@code DEFAULT_ZK_TEST_PORT + forkNumber*1000}); the exact port is still chosen by
+  /// findOpenPort and read back via {@code getZkUrl()}, so no caller depends on the literal base.
   /// The stride (1000) is large enough that a fork exhausting ports below the next boundary
   /// (findOpenPort scans upward) does not spill into the neighboring fork's band.
   private static final int FORK_PORT_OFFSET = forkNumber() * 1000;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
@@ -55,6 +55,11 @@ public class ZkStarter {
   /// findOpenPort and read back via {@code getZkUrl()}, so no caller depends on the literal base.
   /// The stride (1000) is large enough that a fork exhausting ports below the next boundary
   /// (findOpenPort scans upward) does not spill into the neighboring fork's band.
+  ///
+  /// The offset is deliberately centralized on the no-arg entry point rather than pushed into each
+  /// test: several tests across different modules call {@link #startLocalZkServer()} directly, and
+  /// duplicating the fork math into each caller (or introducing a parallel test-only start helper)
+  /// is more surface and more error-prone than one guarded, production-inert read here.
   private static final int FORK_PORT_OFFSET = forkNumber() * 1000;
 
   private static int forkNumber() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +42,22 @@ public class ZkStarter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZkStarter.class);
   public static final int DEFAULT_ZK_TEST_PORT = 2191;
   private static final int DEFAULT_ZK_CLIENT_RETRIES = 10;
+
+  /// Per-fork offset applied to the default test port so that concurrent surefire forks
+  /// (forkCount > 1, reuseForks=false) do not scan from the same base port and collide.
+  /// surefire injects `surefire.forkNumber` (1-based) into each fork; it is absent (0) for
+  /// single-fork/local runs, preserving the historical default of {@link #DEFAULT_ZK_TEST_PORT}.
+  /// The stride (1000) is large enough that a fork exhausting ports below the next boundary
+  /// (findOpenPort scans upward) does not spill into the neighboring fork's band.
+  private static final int FORK_PORT_OFFSET = forkNumber() * 1000;
+
+  private static int forkNumber() {
+    try {
+      return Integer.parseInt(System.getProperty("surefire.forkNumber", "0"));
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
 
   public static class ZookeeperInstance {
     private PublicZooKeeperServerMain _serverMain;
@@ -135,9 +152,10 @@ public class ZkStarter {
     }
   }
 
-  /// Starts an empty local Zk instance on the default port
+  /// Starts an empty local Zk instance on the default port (offset per surefire fork so that
+  /// concurrent forks bind disjoint port ranges).
   public static ZookeeperInstance startLocalZkServer() {
-    return startLocalZkServer(NetUtils.findOpenPort(DEFAULT_ZK_TEST_PORT));
+    return startLocalZkServer(NetUtils.findOpenPort(DEFAULT_ZK_TEST_PORT + FORK_PORT_OFFSET));
   }
 
   public static String getDefaultZkStr() {
@@ -147,8 +165,10 @@ public class ZkStarter {
   /// Starts a local Zk instance with a generated empty data directory
   /// @param port The port to listen on
   public static ZookeeperInstance startLocalZkServer(final int port) {
+    // Use a random UUID rather than a timestamp so that concurrent forks/threads never share a
+    // ZK data directory (System.currentTimeMillis() collides when two instances start in the same ms).
     return startLocalZkServer(port,
-        org.apache.commons.io.FileUtils.getTempDirectoryPath() + File.separator + "test-" + System.currentTimeMillis());
+        org.apache.commons.io.FileUtils.getTempDirectoryPath() + File.separator + "test-" + UUID.randomUUID());
   }
 
   /// Starts a local Zk instance

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -121,18 +122,37 @@ public class ControllerTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerTest.class);
 
   public static final String LOCAL_HOST = "localhost";
+  // Use a random UUID rather than a timestamp so concurrent forks never share a data/temp dir
+  // (System.currentTimeMillis() collides when two forks initialize in the same millisecond).
   public static final String DEFAULT_DATA_DIR = new File(FileUtils.getTempDirectoryPath(),
-      "test-controller-data-dir" + System.currentTimeMillis()).getAbsolutePath();
+      "test-controller-data-dir" + UUID.randomUUID()).getAbsolutePath();
   public static final String DEFAULT_LOCAL_TEMP_DIR = new File(FileUtils.getTempDirectoryPath(),
-      "test-controller-local-temp-dir" + System.currentTimeMillis()).getAbsolutePath();
+      "test-controller-local-temp-dir" + UUID.randomUUID()).getAbsolutePath();
   public static final String BROKER_INSTANCE_ID_PREFIX = "Broker_localhost_";
   public static final String SERVER_INSTANCE_ID_PREFIX = "Server_localhost_";
   public static final String MINION_INSTANCE_ID_PREFIX = "Minion_localhost_";
   public static final String TEST_PORT_BASE_PROPERTY = "pinot.test.port.base";
   public static final String TEST_ZK_PORT_BASE_PROPERTY = "pinot.test.zk.port.base";
 
-  private static final AtomicInteger NEXT_CONFIGURED_ZK_PORT =
-      new AtomicInteger(Integer.getInteger(TEST_ZK_PORT_BASE_PROPERTY, 0));
+  /// Per-fork port offset so that concurrent surefire forks (forkCount > 1, reuseForks=false)
+  /// allocate disjoint port ranges. surefire injects a 1-based `surefire.forkNumber` into each
+  /// fork; it is absent (0) for single-fork/local runs, leaving the historical bases unchanged.
+  /// The stride (5000) comfortably exceeds the ~3000-port span one ControllerTest instance uses.
+  private static final int FORK_PORT_OFFSET = forkNumber() * 5000;
+
+  private static int forkNumber() {
+    try {
+      return Integer.parseInt(System.getProperty("surefire.forkNumber", "0"));
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  // Offset only when an explicit ZK port base is configured; a base of 0 means "let ZkStarter
+  // pick the port" (which is already fork-aware), so it must stay 0 for forked runs too.
+  private static final int CONFIGURED_ZK_PORT_BASE = Integer.getInteger(TEST_ZK_PORT_BASE_PROPERTY, 0);
+  private static final AtomicInteger NEXT_CONFIGURED_ZK_PORT = new AtomicInteger(
+      CONFIGURED_ZK_PORT_BASE > 0 ? CONFIGURED_ZK_PORT_BASE + FORK_PORT_OFFSET : 0);
 
   // Default ControllerTest instance settings
   public static final int DEFAULT_MIN_NUM_REPLICAS = 2;
@@ -150,7 +170,7 @@ public class ControllerTest {
   protected final String _clusterName = getClass().getSimpleName();
   protected final List<HelixManager> _fakeInstanceHelixManagers = new ArrayList<>();
 
-  protected int _nextControllerPort = Integer.getInteger(TEST_PORT_BASE_PROPERTY, 20000);
+  protected int _nextControllerPort = Integer.getInteger(TEST_PORT_BASE_PROPERTY, 20000) + FORK_PORT_OFFSET;
   protected int _nextBrokerPort = _nextControllerPort + 1000;
   protected int _nextBrokerGrpcPort = _nextBrokerPort + 500;
   protected int _nextBrokerQueryRunnerPort = _nextBrokerGrpcPort + 250;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -136,8 +136,10 @@ public class ControllerTest {
 
   /// Per-fork port offset so that concurrent surefire forks (forkCount > 1, reuseForks=false)
   /// allocate disjoint port ranges. surefire injects a 1-based `surefire.forkNumber` into each
-  /// fork; it is absent (0) for single-fork/local runs, leaving the historical bases unchanged.
-  /// The stride (5000) comfortably exceeds the ~3000-port span one ControllerTest instance uses.
+  /// fork (so it is 1 even at forkCount=1, 1..N under parallel forks); it is 0 only outside a
+  /// surefire fork. The stride (5000) comfortably exceeds the ~3000-port span one ControllerTest
+  /// instance uses. Ports are still probed with findOpenPort, so the offset only separates the
+  /// per-fork starting points; no test depends on a literal base port.
   private static final int FORK_PORT_OFFSET = forkNumber() * 5000;
 
   private static int forkNumber() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -216,16 +216,21 @@ public class LuceneMutableTextIndexTest {
     _realtimeLuceneTextIndex.commit();
 
     // Wait for the async NRT index refresh to make the committed documents searchable. A fixed
-    // sleep is flaky under CPU load (the refresh thread may not run in time), so poll a sentinel
-    // query ("stream" -> doc 0 from getTextData) until it is visible, up to a generous timeout.
-    awaitIndexRefreshed();
+    // sleep is flaky under CPU load (the refresh thread may not run in time), so poll until a
+    // sentinel query is visible, up to a generous timeout.
+    //
+    // The sentinel is the regex /.*house.*/ -> doc 1 ("...data warehouses"), which every test in
+    // this class also asserts and which matches under both the default StandardAnalyzer and the
+    // custom KeywordTokenizer (regex matches the single keyword-tokenized term). A term sentinel
+    // like "stream" would never match the keyword-tokenized custom-analyzer cases, making the
+    // barrier spin the full timeout for those tests.
+    awaitIndexRefreshed("/.*house.*/", ImmutableRoaringBitmap.bitmapOf(1));
   }
 
-  private void awaitIndexRefreshed() {
+  private void awaitIndexRefreshed(String sentinelQuery, ImmutableRoaringBitmap expected) {
     long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
-    ImmutableRoaringBitmap expected = ImmutableRoaringBitmap.bitmapOf(0);
     while (true) {
-      if (expected.equals(_realtimeLuceneTextIndex.getDocIds("stream"))) {
+      if (expected.equals(_realtimeLuceneTextIndex.getDocIds(sentinelQuery))) {
         return;
       }
       if (System.nanoTime() >= deadlineNanos) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
@@ -214,11 +215,29 @@ public class LuceneMutableTextIndexTest {
     // ensure searches work after .commit() is called
     _realtimeLuceneTextIndex.commit();
 
-    // sleep for index refresh
-    try {
-      Thread.sleep(100);
-    } catch (Exception e) {
-      // no-op
+    // Wait for the async NRT index refresh to make the committed documents searchable. A fixed
+    // sleep is flaky under CPU load (the refresh thread may not run in time), so poll a sentinel
+    // query ("stream" -> doc 0 from getTextData) until it is visible, up to a generous timeout.
+    awaitIndexRefreshed();
+  }
+
+  private void awaitIndexRefreshed() {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+    ImmutableRoaringBitmap expected = ImmutableRoaringBitmap.bitmapOf(0);
+    while (true) {
+      if (expected.equals(_realtimeLuceneTextIndex.getDocIds("stream"))) {
+        return;
+      }
+      if (System.nanoTime() >= deadlineNanos) {
+        // Fall through and let the caller's assertions report the actual mismatch.
+        return;
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionariesTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionariesTest.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.file.DataFileStream;
@@ -76,7 +77,10 @@ import org.testng.annotations.Test;
 
 public class DictionariesTest implements PinotBuffersAfterMethodCheckRule {
   private static final String AVRO_DATA = "data/test_sample_data.avro";
-  private static final File INDEX_DIR = new File(DictionariesTest.class.toString());
+  // Per-run unique dir so this test never shares an index directory with DictionaryOptimiserTest
+  // (which derived its path from the same class) when the two run concurrently in parallel forks.
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectoryPath(), DictionariesTest.class.getSimpleName() + "-" + UUID.randomUUID());
   private static final Map<String, Set<Object>> UNIQUE_ENTRIES = new HashMap<>();
 
   private static File _segmentDirectory;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.avro.file.DataFileStream;
@@ -60,7 +61,10 @@ public class DictionaryOptimiserTest implements PinotBuffersAfterMethodCheckRule
   private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryOptimiserTest.class);
 
   private static final String AVRO_DATA = "data/mixed_cardinality_data.avro";
-  private static final File INDEX_DIR = new File(DictionariesTest.class.toString());
+  // Per-class unique dir so this test never shares an index directory with DictionariesTest (which
+  // used the same DictionariesTest.class-derived path) when the two run concurrently in parallel forks.
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectoryPath(),
+      DictionaryOptimiserTest.class.getSimpleName() + "-" + UUID.randomUUID());
 
   private static File _segmentDirectory;
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -1093,7 +1093,12 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
 
     // Create inverted index the second time.
     checkInvertedIndexCreation(true);
-    assertEquals(Files.getLastModifiedTime(singleFileIndex.toPath()), newLastModifiedTime);
+    // The second (no-op) creation must not rewrite the file. Compare at millisecond granularity
+    // rather than the FileTime's native nanosecond precision: the 2s sleeps above guarantee that a
+    // real rewrite would move the mtime by ~2000ms, while nanosecond-exact equality is flaky under
+    // CPU load (two getLastModifiedTime syscalls can report sub-microsecond jitter for an untouched
+    // file).
+    assertEquals(Files.getLastModifiedTime(singleFileIndex.toPath()).toMillis(), newLastModifiedTime.toMillis());
     assertEquals(singleFileIndex.length(), newFileSize);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -1093,12 +1093,15 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
 
     // Create inverted index the second time.
     checkInvertedIndexCreation(true);
-    // The second (no-op) creation must not rewrite the file. Compare at millisecond granularity
-    // rather than the FileTime's native nanosecond precision: the 2s sleeps above guarantee that a
-    // real rewrite would move the mtime by ~2000ms, while nanosecond-exact equality is flaky under
-    // CPU load (two getLastModifiedTime syscalls can report sub-microsecond jitter for an untouched
-    // file).
-    assertEquals(Files.getLastModifiedTime(singleFileIndex.toPath()).toMillis(), newLastModifiedTime.toMillis());
+    // The second (no-op) creation must not rewrite the file. Assert the mtime did not advance
+    // meaningfully rather than requiring exact equality: the 2s sleeps above guarantee a real
+    // rewrite would move the mtime by ~2000ms, whereas an untouched file can still report a
+    // sub-millisecond-to-millisecond delta between two getLastModifiedTime reads (filesystem
+    // timestamp granularity / metadata flush), which made exact equality flaky under CPU load.
+    long mtimeDeltaMs =
+        Files.getLastModifiedTime(singleFileIndex.toPath()).toMillis() - newLastModifiedTime.toMillis();
+    assertTrue(Math.abs(mtimeDeltaMs) < 1000,
+        "columns.psf was rewritten by the no-op index recreation (mtime moved " + mtimeDeltaMs + " ms)");
     assertEquals(singleFileIndex.length(), newFileSize);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectoryTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.segment.store;
 
 import java.io.File;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.PinotBuffersAfterClassCheckRule;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -35,7 +36,10 @@ import org.testng.annotations.Test;
 
 
 public class SegmentLocalFSDirectoryTest implements PinotBuffersAfterClassCheckRule {
-  private static final File TEST_DIRECTORY = new File(SingleFileIndexDirectoryTest.class.toString());
+  // Self-scoped unique dir (was derived from SingleFileIndexDirectoryTest.class) so parallel forks
+  // never share a directory.
+  private static final File TEST_DIRECTORY = new File(FileUtils.getTempDirectoryPath(),
+      SegmentLocalFSDirectoryTest.class.getSimpleName() + "-" + UUID.randomUUID());
   private SegmentDirectory _segmentDirectory;
   private SegmentMetadataImpl _metadata;
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,22 @@
     <!-- Only unit tests are run by default. -->
     <skip.integration.tests>true</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>
+    <!--
+      Per-fork heap for unit tests. Defaults to 4g to preserve historical behavior. When
+      running multiple parallel forks (unit.test.fork.count > 1) CI lowers this so that
+      N forks * heap + the Maven JVM stay within the runner's memory.
+    -->
+    <unit.test.fork.heap>4g</unit.test.fork.heap>
     <!-- Sets the VM argument line used when unit tests are run. -->
-    <argLine>-Xms4g -Xmx4g</argLine>
+    <argLine>-Xms${unit.test.fork.heap} -Xmx${unit.test.fork.heap}</argLine>
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
+    <!--
+      Number of parallel JVM forks used by surefire for unit tests. Defaults to 1 to
+      preserve the historical single-fork behavior for local/dev builds. CI overrides
+      this (e.g. -Dunit.test.fork.count=2) to run test classes in parallel forks and
+      shorten the unit-test phase. Must be a positive integer.
+    -->
+    <unit.test.fork.count>1</unit.test.fork.count>
 
     <!-- Checkstyle violation prop.-->
     <checkstyle.violation.severity>warning</checkstyle.violation.severity>
@@ -557,7 +570,9 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
-        <argLine>-Xms4g -Xmx4g -Dlog4j2.configurationFile=log4j2.xml</argLine>
+        <!-- Inherits unit.test.fork.heap from the global properties (overridable via
+             -Dunit.test.fork.heap); adds the log4j2 config used under github-actions. -->
+        <argLine>-Xms${unit.test.fork.heap} -Xmx${unit.test.fork.heap} -Dlog4j2.configurationFile=log4j2.xml</argLine>
       </properties>
     </profile>
     <profile>
@@ -578,6 +593,12 @@
                   <includes>
                     <include>org/apache/pinot/**/*</include>
                   </includes>
+                  <!-- Fork-scope the exec file so concurrent forks (forkCount > 1,
+                       reuseForks=false) never append to the same jacoco.exec and corrupt
+                       coverage. surefire.forkNumber is empty for single-fork runs, yielding
+                       the historical target/jacoco.exec. report-aggregate is invoked with a
+                       matching dataFileIncludes glob (see .pinot_tests_unit.sh). -->
+                  <destFile>${project.build.directory}/jacoco-${surefire.forkNumber}.exec</destFile>
                 </configuration>
               </execution>
             </executions>
@@ -2167,13 +2188,18 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <forkCount>1</forkCount>
+            <!-- Overridable via -Dunit.test.fork.count (defaults to 1); see the property
+                 definition for details. -->
+            <forkCount>${unit.test.fork.count}</forkCount>
             <reuseForks>false</reuseForks>
             <!-- 60 minutes -->
             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
             <!-- Disable zookeeper force sync -->
             <systemPropertyVariables>
               <zookeeper.forceSync>no</zookeeper.forceSync>
+              <!-- Expose the 1-based fork index so tests can offset port bases / temp dirs per
+                   fork when forkCount > 1 (absent/0 for single-fork runs). -->
+              <surefire.forkNumber>${surefire.forkNumber}</surefire.forkNumber>
             </systemPropertyVariables>
             <trimStackTrace>false</trimStackTrace>
             <reportFormat>plain</reportFormat>
@@ -2513,8 +2539,17 @@
           <excludes>
             <exclude>**/*IT.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <!-- forkCount is overridable via -Dunit.test.fork.count (defaults to 1). Each
+               fork runs a distinct test class (reuseForks=false), so raising the count
+               parallelizes classes across JVMs while preserving class-level isolation. -->
+          <forkCount>${unit.test.fork.count}</forkCount>
           <reuseForks>false</reuseForks>
+          <systemPropertyVariables>
+            <!-- Expose the 1-based fork index to tests so port bases / temp dirs can be
+                 offset per fork (see ZkStarter.FORK_PORT_OFFSET, ControllerTest port bases).
+                 Absent/0 for single-fork runs, preserving historical defaults. -->
+            <surefire.forkNumber>${surefire.forkNumber}</surefire.forkNumber>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,13 @@
       shorten the unit-test phase. Must be a positive integer.
     -->
     <unit.test.fork.count>1</unit.test.fork.count>
+    <!--
+      Suffix for the JaCoCo exec file name. Empty by default so coverage writes the
+      historical target/jacoco.exec (used by report / report-aggregate everywhere). The
+      unit-test script sets this to -${surefire.forkNumber} so parallel forks each write a
+      distinct jacoco-<n>.exec instead of appending to one shared file.
+    -->
+    <jacoco.exec.suffix></jacoco.exec.suffix>
 
     <!-- Checkstyle violation prop.-->
     <checkstyle.violation.severity>warning</checkstyle.violation.severity>
@@ -593,12 +600,13 @@
                   <includes>
                     <include>org/apache/pinot/**/*</include>
                   </includes>
-                  <!-- Fork-scope the exec file so concurrent forks (forkCount > 1,
-                       reuseForks=false) never append to the same jacoco.exec and corrupt
-                       coverage. surefire.forkNumber is empty for single-fork runs, yielding
-                       the historical target/jacoco.exec. report-aggregate is invoked with a
-                       matching dataFileIncludes glob (see .pinot_tests_unit.sh). -->
-                  <destFile>${project.build.directory}/jacoco-${surefire.forkNumber}.exec</destFile>
+                  <!-- Exec file suffix defaults to empty, keeping the historical
+                       target/jacoco.exec used by report / report-aggregate everywhere (incl.
+                       the integration lanes). The unit-test script sets jacoco.exec.suffix to
+                       -${surefire.forkNumber} so parallel forks (forkCount > 1) each write a
+                       distinct jacoco-<n>.exec instead of appending to one shared file; it
+                       then aggregates with a matching jacoco-*.exec glob. -->
+                  <destFile>${project.build.directory}/jacoco${jacoco.exec.suffix}.exec</destFile>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
     -->
     <unit.test.fork.count>1</unit.test.fork.count>
     <!--
+      Number of times surefire retries a failing unit test before failing the build. Defaults to
+      0 (no retry) so local/dev behavior is unchanged; CI raises it to absorb a few pre-existing
+      load-sensitive flaky tests exposed by parallel forks. A test passing only on retry is
+      reported as flaky, not silently passed.
+    -->
+    <unit.test.rerun.count>0</unit.test.rerun.count>
+    <!--
       Suffix for the JaCoCo exec file name. Empty by default so coverage writes the
       historical target/jacoco.exec (used by report / report-aggregate everywhere). The
       unit-test script sets this to -${surefire.forkNumber} so parallel forks each write a
@@ -2200,6 +2207,8 @@
                  definition for details. -->
             <forkCount>${unit.test.fork.count}</forkCount>
             <reuseForks>false</reuseForks>
+            <!-- Retries a failing test up to N times (default 0); see property definition. -->
+            <rerunFailingTestsCount>${unit.test.rerun.count}</rerunFailingTestsCount>
             <!-- 60 minutes -->
             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
             <!-- Disable zookeeper force sync -->
@@ -2552,10 +2561,16 @@
                parallelizes classes across JVMs while preserving class-level isolation. -->
           <forkCount>${unit.test.fork.count}</forkCount>
           <reuseForks>false</reuseForks>
+          <!-- Retries a failing test up to N times before marking it failed (default 0 = no
+               retry). CI sets this to tolerate a handful of pre-existing load-sensitive flaky
+               tests (Lucene NRT refresh, filesystem mtime) that surface only when many parallel
+               forks saturate the runner; a test that passes on retry is reported as flaky, not
+               green-washed. -->
+          <rerunFailingTestsCount>${unit.test.rerun.count}</rerunFailingTestsCount>
           <systemPropertyVariables>
-            <!-- Expose the 1-based fork index to tests so port bases / temp dirs can be
-                 offset per fork (see ZkStarter.FORK_PORT_OFFSET, ControllerTest port bases).
-                 Absent/0 for single-fork runs, preserving historical defaults. -->
+            <!-- Expose the 1-based fork index (1 even at forkCount=1, 1..N under parallel forks)
+                 so tests can offset port bases / temp dirs per fork (see ZkStarter.FORK_PORT_OFFSET,
+                 ControllerTest port bases). -->
             <surefire.forkNumber>${surefire.forkNumber}</surefire.forkNumber>
           </systemPropertyVariables>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <!--
       Number of parallel JVM forks used by surefire for unit tests. Defaults to 1 to
       preserve the historical single-fork behavior for local/dev builds. CI overrides
-      this (e.g. -Dunit.test.fork.count=2) to run test classes in parallel forks and
+      this (e.g. -Dunit.test.fork.count=3) to run test classes in parallel forks and
       shorten the unit-test phase. Must be a positive integer.
     -->
     <unit.test.fork.count>1</unit.test.fork.count>


### PR DESCRIPTION
## Motivation

The **Pinot Unit Tests** workflow takes **~63 min** wall-clock (measured across recent `apache/pinot` PR runs). ~83% is a single `mvn test` step that runs **single-threaded** (`forkCount=1`, no `-T`) — using **1 of the runner's 4 vCPUs** for ~50 min.

| Job | Build | Unit Test | Total |
|-----|------:|----------:|------:|
| Set 1 | ~3.4 min | ~50.8 min | ~54 min |
| Set 2 | ~9.5 min | ~52.9 min | ~63 min ← long pole |

## What this PR does

Keeps the existing **2-shard** matrix and parallelizes the test phase **within** each shard.

- **Overridable fork count / heap** — `unit.test.fork.count` (default **1**) and `unit.test.fork.heap` (default **4g**) are new properties; local/dev builds are unchanged. CI opts into **3 forks / 2500m**. `reuseForks=false` keeps one class per JVM (process isolation, not TestNG threading — so `pinot-plugins` and other single-JVM-only tests are unaffected).
- **Fork-safe resource allocation** — ZK/controller test ports and temp dirs are offset per `surefire.forkNumber` (`ZkStarter`, `ControllerTest`); embedded Kafka uses ephemeral ports (Testcontainers / KRaft testkit).
- **Fixed fork-unsafe tests exposed by parallelism** — `DictionariesTest`/`DictionaryOptimiserTest` shared one index dir (derived from `DictionariesTest.class`) and wiped it in `@BeforeClass`; `SegmentLocalFSDirectoryTest` derived its dir from another test's class. All now use per-run UUID dirs.
- **Coverage under parallel forks** — JaCoCo writes per-fork `jacoco-<n>.exec` (only in the unit lane, via `jacoco.exec.suffix`); the integration lanes keep the historical `jacoco.exec`. `report-aggregate` globs `jacoco-*.exec`.
- **Shard rebalance** — `pinot-segment-local`'s tests move from set 2 to set 1 (it's already built in set 1). This offsets set 2's ~3× longer build so both shards finish near-equal.
- **Root-caused two load-sensitive flakes** exposed by parallelism: `SegmentPreProcessorTest` asserted a file mtime at nanosecond precision (now a `< 1s` tolerance — a real rewrite moves it ~2000ms); `LuceneMutableTextIndexTest` used a fixed 100ms sleep for the async NRT refresh (now a bounded poll on an **analyzer-independent** regex sentinel — the naive term sentinel would have spun the 30s timeout for the 5 keyword-tokenizer tests; the class now runs ~7s vs ~150s). An overridable `unit.test.rerun.count` (default 0) remains as an escape hatch but is not enabled by default, so no real failure is masked.

## Local validation (JDK 25)

Measured on a 4-vCPU machine:

- `pinot-query-planner`: 99s → 62s (**1.6×**), 1411 tests, 0 failures.
- `pinot-segment-local`: 106s → 56s on a 40-class subset (**1.9×**); full 5139-test suite ~5.8 min at fork=3.
- **Fork-safety proven**: 4+ ZK/controller test classes run concurrently across 3 forks — 0 `BindException`, BUILD SUCCESS. `jacoco-1/2/3.exec` created and aggregated correctly.
- **Whole `pinot-segment-local` suite green under parallel forks**: 5136 tests at `forkCount=3` with **no retry**, 0 failures / 0 errors — after root-causing the mtime and Lucene-NRT flakes and the shared-temp-dir collisions.

Projected: both shards land in the **mid-to-high 30s min**, clearing 40 with the rebalance absorbing the build asymmetry.

## Backward compatibility

Every new knob defaults to prior behavior (1 fork, 4g, 0 retries, `jacoco.exec`, coverage on). Only CI opts in. To dial back parallelism if a runner shows pressure: `UNIT_TEST_FORK_COUNT=1` in `.pinot_tests_unit.sh` — no pom change needed. Memory: on the GitHub `ubuntu-latest` 16 GB runner, 3 × 2500 m forks + the 2 GB Maven JVM (~9.5 GB) leaves ~6 GB headroom.