### PR TITLE
Add versioned auto-migration for table configs and schemas

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -494,10 +494,24 @@ public class ZKMetadataProvider {
   @Nullable
   public static ImmutablePair<TableConfig, Integer> getTableConfigWithVersion(
       ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
+    return getTableConfigWithVersion(propertyStore, tableNameWithType, true, true);
+  }
+
+  /// @param replaceVariables Whether to replace environment variables and system properties with their actual values
+  /// @param applyDecorator Whether to apply the registered [TableConfigDecoratorRegistry] decorator
+  /// @return a pair of table config and current version from znRecord, null if table config does not exist.
+  ///
+  /// Pass {@code replaceVariables=false, applyDecorator=false} to read the config exactly as stored — needed when the
+  /// config will be transformed and written back (e.g. config migration), so that resolved env vars / decorations are
+  /// not accidentally persisted.
+  @Nullable
+  public static ImmutablePair<TableConfig, Integer> getTableConfigWithVersion(
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType, boolean replaceVariables,
+      boolean applyDecorator) {
     Stat tableConfigStat = new Stat();
     TableConfig tableConfig = toTableConfig(
         propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), tableConfigStat,
-            AccessOption.PERSISTENT));
+            AccessOption.PERSISTENT), replaceVariables, applyDecorator);
     if (tableConfig == null) {
       return null;
     }
@@ -586,7 +600,7 @@ public class ZKMetadataProvider {
       TableConfig tableConfig = TableConfigSerDeUtils.fromZNRecord(znRecord);
       TableConfig processedTableConfig = replaceVariables
           ? ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(tableConfig) : tableConfig;
-      return applyDecorator ? TableConfigDecoratorRegistry.applyDecorator(processedTableConfig) : tableConfig;
+      return applyDecorator ? TableConfigDecoratorRegistry.applyDecorator(processedTableConfig) : processedTableConfig;
     } catch (Exception e) {
       LOGGER.error("Caught exception while creating table config from ZNRecord: {}", znRecord.getId(), e);
       return null;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -47,6 +47,10 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   CONTROLLER_PERIODIC_TASK_ERROR("periodicTaskError", false),
   CONTROLLER_TABLE_SEGMENT_UPLOAD_ERROR("TableSegmentUploadError", false),
   PERIODIC_TASK_ERROR("periodicTaskError", false),
+  // Config migration: a table config or schema was upgraded to a newer version and persisted.
+  CONFIG_MIGRATION_SUCCESS("configMigrationSuccess", false),
+  // Config migration: a table's config/schema migration failed (validation, or lost the CAS race and will retry).
+  CONFIG_MIGRATION_FAILURE("configMigrationFailure", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -108,6 +108,7 @@ import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 import org.apache.pinot.controller.helix.core.minion.TaskMetricsEmitter;
+import org.apache.pinot.controller.helix.core.periodictask.ConfigMigrationManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
@@ -149,6 +150,7 @@ import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.materializedview.consistency.MaterializedViewConsistencyManager;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.segment.local.utils.migration.DefaultConfigMigrationRegistry;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.instance.InstanceConfigValidatorRegistry;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -226,6 +228,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected LeadControllerManager _leadControllerManager;
   protected List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbackList;
   protected StaleInstancesCleanupTask _staleInstancesCleanupTask;
+  protected ConfigMigrationManager _configMigrationManager;
   protected TaskMetricsEmitter _taskMetricsEmitter;
   protected PoolingHttpClientConnectionManager _connectionManager;
   protected TenantRebalancer _tenantRebalancer;
@@ -1094,6 +1097,12 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _staleInstancesCleanupTask =
         new StaleInstancesCleanupTask(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics);
     periodicTasks.add(_staleInstancesCleanupTask);
+    if (_config.isConfigMigrationEnabled()) {
+      _configMigrationManager =
+          new ConfigMigrationManager(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics,
+              DefaultConfigMigrationRegistry.create());
+      periodicTasks.add(_configMigrationManager);
+    }
     _taskMetricsEmitter =
         new TaskMetricsEmitter(_helixResourceManager, _helixTaskResourceManager, _leadControllerManager, _config,
             _controllerMetrics);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -146,6 +146,12 @@ public class ControllerConf extends PinotConfiguration {
     public static final String STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_PERIOD =
         "controller.stale.instances.cleanup.task.minOfflineTimeBeforeDeletionPeriod";
 
+    public static final String CONFIG_MIGRATION_ENABLED = "controller.config.migration.enabled";
+    public static final String CONFIG_MIGRATION_FREQUENCY_PERIOD = "controller.config.migration.frequencyPeriod";
+    public static final String CONFIG_MIGRATION_INITIAL_DELAY_SECONDS =
+        "controller.config.migration.initialDelaySeconds";
+    public static final String CONFIG_MIGRATION_CRON_EXPRESSION = "controller.config.migration.cronExpression";
+
     public static final String TASK_METRICS_EMITTER_FREQUENCY_PERIOD =
         "controller.minion.task.metrics.emitter.frequencyPeriod";
     public static final String TASK_METRICS_EMITTER_CRON_EXPRESSION =
@@ -322,6 +328,12 @@ public class ControllerConf extends PinotConfiguration {
 
     public static final String DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD = "24h";
     public static final String DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_PERIOD = "1h";
+
+    // Config migration is enabled by default so upgraded clusters transparently upgrade stored table configs and
+    // schemas to the current version. It runs on a long cycle (effectively once) because once every config is at the
+    // current version each subsequent run is a cheap no-op.
+    public static final boolean DEFAULT_CONFIG_MIGRATION_ENABLED = true;
+    public static final String DEFAULT_CONFIG_MIGRATION_FREQUENCY_PERIOD = "1h";
 
     // Realtime Consumer Monitor
     public static final String RT_CONSUMER_MONITOR_FREQUENCY_PERIOD =
@@ -1160,6 +1172,29 @@ public class ControllerConf extends PinotConfiguration {
 
   public void setStaleInstancesCleanupTaskInstancesRetentionPeriod(String retentionPeriod) {
     setProperty(ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_PERIOD, retentionPeriod);
+  }
+
+  public boolean isConfigMigrationEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.CONFIG_MIGRATION_ENABLED,
+        ControllerPeriodicTasksConf.DEFAULT_CONFIG_MIGRATION_ENABLED);
+  }
+
+  public int getConfigMigrationFrequencyInSeconds() {
+    String period = getProperty(ControllerPeriodicTasksConf.CONFIG_MIGRATION_FREQUENCY_PERIOD,
+        ControllerPeriodicTasksConf.DEFAULT_CONFIG_MIGRATION_FREQUENCY_PERIOD);
+    if (!isValidPeriodWithLogging(ControllerPeriodicTasksConf.CONFIG_MIGRATION_FREQUENCY_PERIOD, period)) {
+      period = ControllerPeriodicTasksConf.DEFAULT_CONFIG_MIGRATION_FREQUENCY_PERIOD;
+    }
+    return (int) convertPeriodToSeconds(period);
+  }
+
+  public long getConfigMigrationInitialDelaySeconds() {
+    return getProperty(ControllerPeriodicTasksConf.CONFIG_MIGRATION_INITIAL_DELAY_SECONDS,
+        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
+  }
+
+  public String getConfigMigrationCronExpression() {
+    return getProperty(ControllerPeriodicTasksConf.CONFIG_MIGRATION_CRON_EXPRESSION);
   }
 
   public int getDefaultTableMinReplicas() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ConfigMigrationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ConfigMigrationManager.java
@@ -1,0 +1,171 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.periodictask;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.spi.config.migration.ConfigMigrationRegistry;
+import org.apache.pinot.spi.config.migration.MigrationResult;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Controller periodic task that transparently upgrades stored [TableConfig]s and [Schema]s to the
+/// current migration version, so that a cluster upgrade does not surprise users with configs the new
+/// controller can no longer parse or validate.
+///
+/// For every table this controller leads, the task:
+/// 1. Reads the config **exactly as stored** (no env-var substitution, no decorator) together with
+///    its ZK version.
+/// 2. Runs the [ConfigMigrationRegistry] chain. If nothing changed (already at the current version),
+///    it writes nothing.
+/// 3. Persists the migrated config through the standard [PinotHelixResourceManager] write path
+///    (`setExistingTableConfig` / `updateSchema`), which validates the config, performs a
+///    version-checked write, and — crucially — sends the broker/server cache-refresh messages so
+///    in-memory caches converge. A concurrent operator edit is never clobbered: the version check
+///    fails, the write is skipped, and the table is retried on the next cycle.
+/// 4. Migrates the table's schema the same way (deduplicated across a table's OFFLINE/REALTIME halves
+///    within a single run, since they share one schema).
+///
+/// Note: the table-config and schema writes are two independent operations; a migration that must
+/// change both atomically cannot be expressed in this model and would need a different mechanism.
+///
+/// The task is idempotent: once every config is at the current version, subsequent runs are cheap
+/// no-ops. Leadership and per-table iteration are handled by [ControllerPeriodicTask].
+public class ConfigMigrationManager extends ControllerPeriodicTask<ConfigMigrationManager.Context> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigMigrationManager.class);
+  public static final String TASK_NAME = ConfigMigrationManager.class.getSimpleName();
+
+  private final ConfigMigrationRegistry _migrationRegistry;
+
+  public ConfigMigrationManager(PinotHelixResourceManager helixResourceManager,
+      LeadControllerManager leadControllerManager, ControllerConf config, ControllerMetrics controllerMetrics,
+      ConfigMigrationRegistry migrationRegistry) {
+    super(TASK_NAME, config.getConfigMigrationFrequencyInSeconds(), config.getConfigMigrationInitialDelaySeconds(),
+        config.getConfigMigrationCronExpression(), helixResourceManager, leadControllerManager, controllerMetrics);
+    _migrationRegistry = migrationRegistry;
+  }
+
+  /// Per-run context tracking which schemas were already migrated, so a hybrid table's OFFLINE and
+  /// REALTIME halves don't both attempt to migrate the shared schema. Tables are processed sequentially
+  /// within a single run (see [ControllerPeriodicTask#processTables]), so a plain [HashSet] is sufficient.
+  public static class Context {
+    private final Set<String> _processedSchemas = new HashSet<>();
+  }
+
+  @Override
+  protected Context preprocess(Properties periodicTaskProperties) {
+    return new Context();
+  }
+
+  @Override
+  protected void processTable(String tableNameWithType, Context context) {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+    migrateTableConfig(propertyStore, tableNameWithType);
+
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    // Schema is shared between the OFFLINE and REALTIME halves of a table; migrate it at most once per run.
+    if (context._processedSchemas.add(rawTableName)) {
+      migrateSchema(rawTableName);
+    }
+  }
+
+  private void migrateTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
+    // Read the config as stored (no variable substitution, no decorator) together with its ZK version, so we never
+    // persist resolved env-var values and can perform a version-checked write.
+    ImmutablePair<TableConfig, Integer> configAndVersion =
+        ZKMetadataProvider.getTableConfigWithVersion(propertyStore, tableNameWithType, false, false);
+    if (configAndVersion == null) {
+      return;
+    }
+    TableConfig tableConfig = configAndVersion.getLeft();
+    int expectedVersion = configAndVersion.getRight();
+
+    MigrationResult<TableConfig> result = _migrationRegistry.migrateTableConfig(tableConfig);
+    if (!result.isChanged()) {
+      return;
+    }
+    TableConfig migrated = result.getConfig();
+
+    // Validate before persisting so a buggy migrator can never write an invalid config into ZK. A missing schema is
+    // an expected transient state (e.g. schema not yet created), not a migration failure — skip quietly and retry.
+    Schema schema = _pinotHelixResourceManager.getSchema(TableNameBuilder.extractRawTableName(tableNameWithType));
+    if (schema == null) {
+      LOGGER.info("Skipping table config migration for table: {}; schema not found yet, will retry", tableNameWithType);
+      return;
+    }
+    try {
+      TableConfigUtils.validate(migrated, schema);
+    } catch (Exception e) {
+      LOGGER.error("Migrated table config for table: {} failed validation; skipping persist", tableNameWithType, e);
+      _controllerMetrics.addMeteredTableValue(tableNameWithType, ControllerMeter.CONFIG_MIGRATION_FAILURE, 1L);
+      return;
+    }
+
+    // Persist through the standard resource-manager path: version-checked write + broker/server cache-refresh messages.
+    try {
+      _pinotHelixResourceManager.setExistingTableConfig(migrated, expectedVersion, true);
+      LOGGER.info("Migrated table config for table: {} to version: {}", tableNameWithType, result.getVersion());
+      _controllerMetrics.addMeteredTableValue(tableNameWithType, ControllerMeter.CONFIG_MIGRATION_SUCCESS, 1L);
+    } catch (Exception e) {
+      // Most likely lost the optimistic-concurrency race with a concurrent update; will retry on the next cycle.
+      LOGGER.warn("Failed to persist migrated table config for table: {} (expected version: {}); will retry",
+          tableNameWithType, expectedVersion, e);
+      _controllerMetrics.addMeteredTableValue(tableNameWithType, ControllerMeter.CONFIG_MIGRATION_FAILURE, 1L);
+    }
+  }
+
+  private void migrateSchema(String schemaName) {
+    Schema schema = _pinotHelixResourceManager.getSchema(schemaName);
+    if (schema == null) {
+      return;
+    }
+
+    MigrationResult<Schema> result = _migrationRegistry.migrateSchema(schema);
+    if (!result.isChanged()) {
+      return;
+    }
+    Schema migrated = result.getConfig();
+
+    // Persist through the standard resource-manager path, which validates, writes, and sends schema-refresh messages.
+    // reload=false: a version-marker bump does not change any field, so segments do not need reloading.
+    try {
+      _pinotHelixResourceManager.updateSchema(migrated, false, true);
+      LOGGER.info("Migrated schema: {} to version: {}", schemaName, result.getVersion());
+      _controllerMetrics.addMeteredTableValue(schemaName, ControllerMeter.CONFIG_MIGRATION_SUCCESS, 1L);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to persist migrated schema: {}; will retry", schemaName, e);
+      _controllerMetrics.addMeteredTableValue(schemaName, ControllerMeter.CONFIG_MIGRATION_FAILURE, 1L);
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ConfigMigrationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ConfigMigrationManagerTest.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.periodictask;
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.segment.local.utils.migration.DefaultConfigMigrationRegistry;
+import org.apache.pinot.spi.config.migration.ConfigMigrationRegistry;
+import org.apache.pinot.spi.config.migration.ConfigMigrationUtils;
+import org.apache.pinot.spi.config.migration.SchemaMigrator;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.zookeeper.data.Stat;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+public class ConfigMigrationManagerTest {
+  private static final String RAW_TABLE_NAME = "myTable";
+  private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
+  private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
+  private static final String CONFIG_PATH = "/CONFIGS/TABLE/" + OFFLINE_TABLE_NAME;
+
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private PinotHelixResourceManager _resourceManager;
+  private ControllerMetrics _controllerMetrics;
+
+  @SuppressWarnings("unchecked")
+  @BeforeMethod
+  public void setUp() {
+    _propertyStore = mock(ZkHelixPropertyStore.class);
+    _resourceManager = mock(PinotHelixResourceManager.class);
+    when(_resourceManager.getPropertyStore()).thenReturn(_propertyStore);
+    _controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+  }
+
+  private ConfigMigrationManager newManager(ConfigMigrationRegistry registry) {
+    return new ConfigMigrationManager(_resourceManager, mock(LeadControllerManager.class), new ControllerConf(),
+        _controllerMetrics, registry);
+  }
+
+  private void stubStoredTableConfig(TableConfig tableConfig, int zkVersion)
+      throws Exception {
+    ZNRecord znRecord = TableConfigSerDeUtils.toZNRecord(tableConfig);
+    when(_propertyStore.get(eq(CONFIG_PATH), any(), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
+      Stat stat = invocation.getArgument(1);
+      if (stat != null) {
+        stat.setVersion(zkVersion);
+      }
+      return znRecord;
+    });
+  }
+
+  private static TableConfig legacyTableConfig() {
+    // OFFLINE avoids a required stream config; the deprecated batch push fields still trigger a v0 -> v1 migration.
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setSegmentPushType("APPEND")
+        .setSegmentPushFrequency("HOURLY")
+        .build();
+  }
+
+  private static Schema validSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addSingleValueDimension("d", DataType.STRING)
+        .build();
+  }
+
+  private long meterValue(ControllerMeter meter) {
+    return _controllerMetrics.getMeteredTableValue(OFFLINE_TABLE_NAME, meter).count();
+  }
+
+  @Test
+  public void testMigratesAndPersistsThroughResourceManagerWithVersionCheck()
+      throws Exception {
+    stubStoredTableConfig(legacyTableConfig(), 7);
+    when(_resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(validSchema());
+
+    newManager(DefaultConfigMigrationRegistry.create())
+        .processTable(OFFLINE_TABLE_NAME, new ConfigMigrationManager.Context());
+
+    // Persisted through the standard write path (which sends cache-refresh messages) with the exact ZK version read.
+    ArgumentCaptor<TableConfig> captor = ArgumentCaptor.forClass(TableConfig.class);
+    verify(_resourceManager).setExistingTableConfig(captor.capture(), eq(7), eq(true));
+    TableConfig persisted = captor.getValue();
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(persisted), 1);
+    // Deprecated fields folded into ingestionConfig and cleared.
+    assertEquals(persisted.getValidationConfig().getSegmentPushType(), null);
+    assertEquals(meterValue(ControllerMeter.CONFIG_MIGRATION_SUCCESS), 1L);
+  }
+
+  @Test
+  public void testAlreadyCurrentConfigIsNotWritten()
+      throws Exception {
+    TableConfig current = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    ConfigMigrationUtils.setTableConfigVersion(current, 1);
+    stubStoredTableConfig(current, 3);
+
+    newManager(DefaultConfigMigrationRegistry.create())
+        .processTable(OFFLINE_TABLE_NAME, new ConfigMigrationManager.Context());
+
+    verify(_resourceManager, never()).setExistingTableConfig(any(), anyInt(), anyBoolean());
+  }
+
+  @Test
+  public void testMissingSchemaSkipsWithoutFailureMetric()
+      throws Exception {
+    stubStoredTableConfig(legacyTableConfig(), 7);
+    when(_resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(null);
+
+    newManager(DefaultConfigMigrationRegistry.create())
+        .processTable(OFFLINE_TABLE_NAME, new ConfigMigrationManager.Context());
+
+    // A not-yet-created schema is a transient state, not a migration failure: skip quietly and do not persist.
+    verify(_resourceManager, never()).setExistingTableConfig(any(), anyInt(), anyBoolean());
+    assertEquals(meterValue(ControllerMeter.CONFIG_MIGRATION_FAILURE), 0L);
+  }
+
+  @Test
+  public void testPersistFailureIsCaughtAndMetered()
+      throws Exception {
+    stubStoredTableConfig(legacyTableConfig(), 7);
+    when(_resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(validSchema());
+    // Simulate a lost optimistic-concurrency race: the resource manager throws on the version-checked write.
+    doThrow(new RuntimeException("version mismatch")).when(_resourceManager)
+        .setExistingTableConfig(any(), eq(7), eq(true));
+
+    // Should complete without propagating; the table will be retried on the next cycle.
+    newManager(DefaultConfigMigrationRegistry.create())
+        .processTable(OFFLINE_TABLE_NAME, new ConfigMigrationManager.Context());
+
+    verify(_resourceManager).setExistingTableConfig(any(), eq(7), eq(true));
+    assertEquals(meterValue(ControllerMeter.CONFIG_MIGRATION_FAILURE), 1L);
+  }
+
+  @Test
+  public void testSchemaMigratedOnlyOncePerRunAcrossHybridHalves()
+      throws Exception {
+    // Register a real (identity) schema migrator so "migrated once" is a non-vacuous assertion.
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    registry.registerSchemaMigrator(new IdentitySchemaMigrator());
+    stubStoredTableConfig(currentOfflineConfig(), 1);
+    when(_resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(validSchema());
+
+    ConfigMigrationManager manager = newManager(registry);
+    ConfigMigrationManager.Context context = new ConfigMigrationManager.Context();
+    manager.processTable(OFFLINE_TABLE_NAME, context);
+    manager.processTable(REALTIME_TABLE_NAME, context);
+
+    // The shared schema is migrated exactly once across both hybrid halves.
+    verify(_resourceManager, times(1)).updateSchema(any(), eq(false), eq(true));
+  }
+
+  private static TableConfig currentOfflineConfig() {
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    // Already at the current table-config version so the run focuses on the schema path.
+    ConfigMigrationUtils.setTableConfigVersion(config, DefaultConfigMigrationRegistry.create()
+        .getCurrentTableConfigVersion());
+    return config;
+  }
+
+  /// A schema migrator that advances v0 -> v1 without changing any field, used to make the schema path observable.
+  private static final class IdentitySchemaMigrator implements SchemaMigrator {
+    @Override
+    public int fromVersion() {
+      return 0;
+    }
+
+    @Override
+    public Schema migrate(Schema input) {
+      return input;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/migration/DefaultConfigMigrationRegistry.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/migration/DefaultConfigMigrationRegistry.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils.migration;
+
+import org.apache.pinot.spi.config.migration.ConfigMigrationRegistry;
+
+
+/// Assembles the built-in [ConfigMigrationRegistry] with the migration chain shipped by Pinot.
+///
+/// This is the single place that declares the ordered set of migrators, and therefore defines the
+/// current table-config and schema migration versions. Add a new migrator to the end of the relevant
+/// chain (with `fromVersion` equal to the current chain length) to introduce a new upgrade step.
+///
+/// Table-config chain:
+/// - v0 -> v1: [LegacyIngestionConfigMigrator] (fold deprecated ingestion fields into ingestionConfig)
+///
+/// Schema chain:
+/// - (none yet) The framework is wired end-to-end; the current schema version is 0, so schemas are
+///   never rewritten until a real schema migrator is added here.
+public class DefaultConfigMigrationRegistry {
+  private DefaultConfigMigrationRegistry() {
+  }
+
+  /// Builds a fresh registry populated with the built-in migration chain.
+  public static ConfigMigrationRegistry create() {
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    registry.registerTableConfigMigrator(new LegacyIngestionConfigMigrator());
+    // No schema migrators yet; add them here (fromVersion == current schema chain length) as needed.
+    return registry;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/migration/LegacyIngestionConfigMigrator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/migration/LegacyIngestionConfigMigrator.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils.migration;
+
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.spi.config.migration.TableConfigMigrator;
+import org.apache.pinot.spi.config.table.TableConfig;
+
+
+/// Migrates a [TableConfig] from migration version 0 (pre-framework) to version 1 by folding the
+/// deprecated ingestion-related fields into [org.apache.pinot.spi.config.table.ingestion.IngestionConfig]:
+///
+/// - `tableIndexConfig.streamConfigs` -> `ingestionConfig.streamIngestionConfig`
+/// - `segmentsConfig.segmentPushType` / `segmentPushFrequency` -> `ingestionConfig.batchIngestionConfig`
+///
+/// The transform delegates to [TableConfigUtils#convertFromLegacyTableConfig(TableConfig)], which
+/// mutates the config in place and clears the deprecated fields. Configs that already use the
+/// current ingestion shape are left effectively unchanged (the deprecated fields are simply null).
+public class LegacyIngestionConfigMigrator implements TableConfigMigrator {
+
+  @Override
+  public int fromVersion() {
+    return 0;
+  }
+
+  @Override
+  public TableConfig migrate(TableConfig input) {
+    TableConfigUtils.convertFromLegacyTableConfig(input);
+    return input;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/migration/LegacyIngestionConfigMigratorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/migration/LegacyIngestionConfigMigratorTest.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils.migration;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
+import org.apache.pinot.spi.config.migration.ConfigMigrationRegistry;
+import org.apache.pinot.spi.config.migration.ConfigMigrationUtils;
+import org.apache.pinot.spi.config.migration.MigrationResult;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class LegacyIngestionConfigMigratorTest {
+
+  private static Map<String, String> streamConfigs() {
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, "kafka");
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty("kafka", StreamConfigProperties.STREAM_TOPIC_NAME), "topic");
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty("kafka", StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS),
+        "cf");
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty("kafka", StreamConfigProperties.STREAM_DECODER_CLASS), "dec");
+    return streamConfigMap;
+  }
+
+  @Test
+  public void testDefaultRegistryUpgradesLegacyTableConfig() {
+    Map<String, String> streamConfigs = streamConfigs();
+    TableConfig legacy = new TableConfigBuilder(TableType.REALTIME).setTableName("legacyTable")
+        .setSegmentPushType("APPEND")
+        .setSegmentPushFrequency("HOURLY")
+        .setStreamConfigs(streamConfigs)
+        .build();
+    assertNull(legacy.getIngestionConfig());
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(legacy), 0);
+
+    ConfigMigrationRegistry registry = DefaultConfigMigrationRegistry.create();
+    assertEquals(registry.getCurrentTableConfigVersion(), 1);
+
+    MigrationResult<TableConfig> result = registry.migrateTableConfig(legacy);
+    assertTrue(result.isChanged());
+    assertEquals(result.getVersion(), 1);
+
+    TableConfig migrated = result.getConfig();
+    // Deprecated ingestion fields are folded into ingestionConfig.
+    IngestionConfig ingestionConfig = migrated.getIngestionConfig();
+    assertNotNull(ingestionConfig);
+    assertNotNull(ingestionConfig.getBatchIngestionConfig());
+    assertEquals(ingestionConfig.getBatchIngestionConfig().getSegmentIngestionType(), "APPEND");
+    assertNotNull(ingestionConfig.getStreamIngestionConfig());
+    assertEquals(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps().get(0), streamConfigs);
+    // Deprecated fields are cleared and the version marker is stamped.
+    assertNull(migrated.getIndexingConfig().getStreamConfigs());
+    assertNull(migrated.getValidationConfig().getSegmentPushType());
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(migrated), 1);
+  }
+
+  @Test
+  public void testUpgradesDeprecatedStreamConfigsOnly() {
+    // A REALTIME table whose only deprecated field is tableIndexConfig.streamConfigs.
+    Map<String, String> streamConfigs = streamConfigs();
+    TableConfig legacy = new TableConfigBuilder(TableType.REALTIME).setTableName("streamOnly")
+        .setStreamConfigs(streamConfigs)
+        .build();
+
+    MigrationResult<TableConfig> result = DefaultConfigMigrationRegistry.create().migrateTableConfig(legacy);
+    assertTrue(result.isChanged());
+    TableConfig migrated = result.getConfig();
+    assertNotNull(migrated.getIngestionConfig().getStreamIngestionConfig());
+    assertEquals(migrated.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps().get(0), streamConfigs);
+    assertNull(migrated.getIndexingConfig().getStreamConfigs());
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(migrated), 1);
+  }
+
+  @Test
+  public void testUpgradesDeprecatedBatchPushConfigsOnly() {
+    // An OFFLINE table whose only deprecated fields are the segmentsConfig batch push settings.
+    TableConfig legacy = new TableConfigBuilder(TableType.OFFLINE).setTableName("batchOnly")
+        .setSegmentPushType("REFRESH")
+        .setSegmentPushFrequency("DAILY")
+        .build();
+
+    MigrationResult<TableConfig> result = DefaultConfigMigrationRegistry.create().migrateTableConfig(legacy);
+    assertTrue(result.isChanged());
+    TableConfig migrated = result.getConfig();
+    BatchIngestionConfig batchIngestionConfig = migrated.getIngestionConfig().getBatchIngestionConfig();
+    assertNotNull(batchIngestionConfig);
+    assertEquals(batchIngestionConfig.getSegmentIngestionType(), "REFRESH");
+    assertEquals(batchIngestionConfig.getSegmentIngestionFrequency(), "DAILY");
+    assertNull(migrated.getValidationConfig().getSegmentPushType());
+    assertNull(migrated.getValidationConfig().getSegmentPushFrequency());
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(migrated), 1);
+  }
+
+  @Test
+  public void testUpgradeSurvivesZkSerializationRoundTrip()
+      throws Exception {
+    // Simulate the real controller flow: an old version stored a deprecated config as a ZNRecord; the migration task
+    // reads it back, migrates, and the upgraded config re-serializes cleanly with the version marker persisted.
+    TableConfig legacy = new TableConfigBuilder(TableType.REALTIME).setTableName("roundTrip")
+        .setSegmentPushType("APPEND")
+        .setStreamConfigs(streamConfigs())
+        .build();
+
+    // Round-trip through the ZK ZNRecord form used by ZKMetadataProvider.
+    TableConfig stored = TableConfigSerDeUtils.fromZNRecord(TableConfigSerDeUtils.toZNRecord(legacy));
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(stored), 0);
+
+    MigrationResult<TableConfig> result = DefaultConfigMigrationRegistry.create().migrateTableConfig(stored);
+    assertTrue(result.isChanged());
+
+    // Re-serialize the migrated config (as the task persists it) and read it back: upgrade + marker both survive.
+    TableConfig persisted = TableConfigSerDeUtils.fromZNRecord(TableConfigSerDeUtils.toZNRecord(result.getConfig()));
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(persisted), 1);
+    assertNotNull(persisted.getIngestionConfig().getStreamIngestionConfig());
+    assertNotNull(persisted.getIngestionConfig().getBatchIngestionConfig());
+    assertNull(persisted.getIndexingConfig().getStreamConfigs());
+    assertNull(persisted.getValidationConfig().getSegmentPushType());
+  }
+
+  @Test
+  public void testAlreadyMigratedConfigIsNoOp() {
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE).setTableName("currentTable").build();
+    ConfigMigrationUtils.setTableConfigVersion(config, 1);
+
+    ConfigMigrationRegistry registry = DefaultConfigMigrationRegistry.create();
+    MigrationResult<TableConfig> result = registry.migrateTableConfig(config);
+    assertFalse(result.isChanged());
+    assertEquals(result.getVersion(), 1);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/ConfigMigrationRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/ConfigMigrationRegistry.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+/// Registry of ordered [ConfigMigrator]s that upgrade stored [TableConfig] and [Schema] objects to
+/// the current migration version.
+///
+/// Migrators form a dense chain: the migrator at index {@code i} declares {@code fromVersion() == i}
+/// and produces version {@code i + 1}. The current version is therefore the number of registered
+/// migrators. Given a config at version {@code v}, [#migrateTableConfig]/[#migrateSchema] apply every
+/// migrator with {@code fromVersion() >= v} in order, returning a [MigrationResult] whose
+/// {@code changed} flag tells the caller whether a write-back is needed.
+///
+/// Migrators are registered once during startup (before any migration runs) and the registry is then
+/// read-only, so migration itself is thread-safe across tables. Registration is guarded to enforce
+/// the dense, in-order contract.
+///
+/// The default no-migrator registry (current version 0) is a safe identity: every config is already
+/// current and nothing is rewritten.
+public class ConfigMigrationRegistry {
+  private final List<TableConfigMigrator> _tableConfigMigrators = new ArrayList<>();
+  private final List<SchemaMigrator> _schemaMigrators = new ArrayList<>();
+
+  /// Registers the next table-config migrator. Its [ConfigMigrator#fromVersion()] must equal the
+  /// current number of registered table-config migrators, keeping the chain dense and in order.
+  public synchronized void registerTableConfigMigrator(TableConfigMigrator migrator) {
+    Preconditions.checkArgument(migrator.fromVersion() == _tableConfigMigrators.size(),
+        "TableConfig migrator fromVersion %s does not match expected version %s (migrators must be registered in "
+            + "dense, ascending order)", migrator.fromVersion(), _tableConfigMigrators.size());
+    _tableConfigMigrators.add(migrator);
+  }
+
+  /// Registers the next schema migrator. Its [ConfigMigrator#fromVersion()] must equal the current
+  /// number of registered schema migrators, keeping the chain dense and in order.
+  public synchronized void registerSchemaMigrator(SchemaMigrator migrator) {
+    Preconditions.checkArgument(migrator.fromVersion() == _schemaMigrators.size(),
+        "Schema migrator fromVersion %s does not match expected version %s (migrators must be registered in dense, "
+            + "ascending order)", migrator.fromVersion(), _schemaMigrators.size());
+    _schemaMigrators.add(migrator);
+  }
+
+  /// The current table-config migration version, i.e. the number of registered table-config migrators.
+  public int getCurrentTableConfigVersion() {
+    return _tableConfigMigrators.size();
+  }
+
+  /// The current schema migration version, i.e. the number of registered schema migrators.
+  public int getCurrentSchemaVersion() {
+    return _schemaMigrators.size();
+  }
+
+  /// Migrates the given table config from its stored version up to [#getCurrentTableConfigVersion()].
+  /// The returned config carries the stamped version marker. If no migrator applied, the result wraps
+  /// the original config unchanged.
+  public MigrationResult<TableConfig> migrateTableConfig(TableConfig tableConfig) {
+    int currentVersion = ConfigMigrationUtils.getTableConfigVersion(tableConfig);
+    TableConfig migrated = migrate(tableConfig, currentVersion, _tableConfigMigrators);
+    int targetVersion = getCurrentTableConfigVersion();
+    boolean changed = currentVersion < targetVersion;
+    if (changed) {
+      ConfigMigrationUtils.setTableConfigVersion(migrated, targetVersion);
+    }
+    return new MigrationResult<>(migrated, targetVersion, changed);
+  }
+
+  /// Migrates the given schema from its stored version up to [#getCurrentSchemaVersion()]. The
+  /// returned schema carries the stamped version marker. If no migrator applied, the result wraps the
+  /// original schema unchanged.
+  public MigrationResult<Schema> migrateSchema(Schema schema) {
+    int currentVersion = ConfigMigrationUtils.getSchemaVersion(schema);
+    Schema migrated = migrate(schema, currentVersion, _schemaMigrators);
+    int targetVersion = getCurrentSchemaVersion();
+    boolean changed = currentVersion < targetVersion;
+    if (changed) {
+      ConfigMigrationUtils.setSchemaVersion(migrated, targetVersion);
+    }
+    return new MigrationResult<>(migrated, targetVersion, changed);
+  }
+
+  /// Applies every migrator whose {@code fromVersion() >= currentVersion} in ascending order. The
+  /// migrator list is already dense and ordered by registration (enforced at registration time), so
+  /// this walks the tail starting at {@code currentVersion}. A stored version above the current
+  /// version (e.g. after a controller downgrade) leaves the config untouched.
+  private static <T, M extends ConfigMigrator<T>> T migrate(T config, int currentVersion, List<M> migrators) {
+    T result = config;
+    for (int version = currentVersion; version < migrators.size(); version++) {
+      result = migrators.get(version).migrate(result);
+    }
+    return result;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/ConfigMigrationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/ConfigMigrationUtils.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableCustomConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+/// Reads and stamps the migration-version marker on [TableConfig] and [Schema].
+///
+/// The marker records the highest migration version that has been applied to a stored config, so
+/// the migration chain can resume from the right step and skip configs that are already current.
+///
+/// - **TableConfig**: the marker lives under [#MIGRATION_VERSION_KEY] in
+///   [TableCustomConfig#getCustomConfigs()]. Storing it in the free-form custom-config map avoids
+///   adding a first-class SPI field and keeps mixed-version rollback safe (older controllers simply
+///   preserve the unknown key).
+/// - **Schema**: the marker is the dedicated {@code configMigrationVersion} field on [Schema], which
+///   older readers ignore via {@code @JsonIgnoreProperties(ignoreUnknown = true)}.
+///
+/// A missing or unparseable marker is treated as version {@link #INITIAL_VERSION} (0) — the state of
+/// any config written before this framework existed.
+public class ConfigMigrationUtils {
+  private ConfigMigrationUtils() {
+  }
+
+  /// Reserved custom-config key under which a table config's applied migration version is stored.
+  ///
+  /// This key is **controller-managed**: it is written by the config-migration task and is visible in the table
+  /// config's `metadata.customConfigs` in REST responses. Operators should not set or edit it; a user-provided value
+  /// is overwritten on the next migration. Other custom-config entries are preserved untouched.
+  public static final String MIGRATION_VERSION_KEY = "config.migration.version";
+
+  /// The version assigned to configs written before the migration framework existed.
+  public static final int INITIAL_VERSION = 0;
+
+  /// Returns the migration version recorded on the given table config, or {@link #INITIAL_VERSION}
+  /// if the marker is absent or unparseable.
+  public static int getTableConfigVersion(TableConfig tableConfig) {
+    TableCustomConfig customConfig = tableConfig.getCustomConfig();
+    Map<String, String> customConfigs = customConfig != null ? customConfig.getCustomConfigs() : null;
+    if (customConfigs == null) {
+      return INITIAL_VERSION;
+    }
+    return parseVersion(customConfigs.get(MIGRATION_VERSION_KEY));
+  }
+
+  /// Stamps the given migration version onto the table config's custom-config map in place, creating
+  /// the [TableCustomConfig] if necessary. Existing custom configs are preserved.
+  public static void setTableConfigVersion(TableConfig tableConfig, int version) {
+    TableCustomConfig existing = tableConfig.getCustomConfig();
+    // getCustomConfig() never returns null, but the backing map may be immutable, so always copy.
+    Map<String, String> customConfigs =
+        existing.getCustomConfigs() != null ? new LinkedHashMap<>(existing.getCustomConfigs()) : new LinkedHashMap<>();
+    customConfigs.put(MIGRATION_VERSION_KEY, Integer.toString(version));
+    tableConfig.setCustomConfig(new TableCustomConfig(customConfigs));
+  }
+
+  /// Returns the migration version recorded on the given schema.
+  public static int getSchemaVersion(Schema schema) {
+    return schema.getConfigMigrationVersion();
+  }
+
+  /// Stamps the given migration version onto the schema in place.
+  public static void setSchemaVersion(Schema schema, int version) {
+    schema.setConfigMigrationVersion(version);
+  }
+
+  private static int parseVersion(String value) {
+    if (value == null) {
+      return INITIAL_VERSION;
+    }
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return INITIAL_VERSION;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/ConfigMigrator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/ConfigMigrator.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+/// A single step in a versioned migration chain that upgrades a configuration object from one
+/// migration version to the next.
+///
+/// Each migrator advances a config exactly one version: it accepts an input at version
+/// [#fromVersion()] and returns an equivalent config at version {@code fromVersion() + 1}. The
+/// [ConfigMigrationRegistry] composes an ordered list of migrators to bring a config from any
+/// stored version up to the current version.
+///
+/// Implementations must be:
+/// - **Pure with respect to versioning**: a migrator for {@code fromVersion() == N} must only ever
+///   run against configs at version {@code N}.
+/// - **Idempotent-safe**: the registry never runs a migrator against a config already at or beyond
+///   {@code fromVersion() + 1}, so implementations only need to handle the version they declare.
+/// - **Thread-safe**: migrators are singletons registered once at startup and may be invoked
+///   concurrently for different tables.
+///
+/// @param <T> the configuration type being migrated (e.g. {@code TableConfig} or {@code Schema})
+public interface ConfigMigrator<T> {
+
+  /// The migration version this migrator upgrades **from**. The result of [#migrate(Object)] is at
+  /// version {@code fromVersion() + 1}. Versions are dense, non-negative integers starting at 0
+  /// (0 represents a config written before the migration framework existed).
+  int fromVersion();
+
+  /// Upgrades the given config from [#fromVersion()] to {@code fromVersion() + 1}.
+  ///
+  /// Implementations may either mutate {@code input} in place and return it, or return a new
+  /// object. The version marker itself is stamped by the registry, not by the migrator.
+  ///
+  /// @param input config at version [#fromVersion()]
+  /// @return an equivalent config at version {@code fromVersion() + 1}
+  T migrate(T input);
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/MigrationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/MigrationResult.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+/// The outcome of running the migration chain over a single config object.
+///
+/// - [#getConfig()] is the (possibly upgraded) config. When [#isChanged()] is {@code false} this is
+///   the same instance that was passed in.
+/// - [#getVersion()] is the migration version of [#getConfig()] — always equal to the registry's
+///   current version after a successful migration.
+/// - [#isChanged()] is {@code true} when at least one migrator was applied, i.e. the stored config
+///   was at an older version and must be persisted. When {@code false}, the caller should skip the
+///   write entirely.
+///
+/// @param <T> the configuration type (e.g. {@code TableConfig} or {@code Schema})
+public class MigrationResult<T> {
+  private final T _config;
+  private final int _version;
+  private final boolean _changed;
+
+  public MigrationResult(T config, int version, boolean changed) {
+    _config = config;
+    _version = version;
+    _changed = changed;
+  }
+
+  public T getConfig() {
+    return _config;
+  }
+
+  public int getVersion() {
+    return _version;
+  }
+
+  public boolean isChanged() {
+    return _changed;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/SchemaMigrator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/SchemaMigrator.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+import org.apache.pinot.spi.data.Schema;
+
+
+/// A [ConfigMigrator] that upgrades a [Schema] from one migration version to the next.
+///
+/// Register concrete implementations with [ConfigMigrationRegistry#registerSchemaMigrator] so they
+/// participate in the startup migration chain run by the controller.
+public interface SchemaMigrator extends ConfigMigrator<Schema> {
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/TableConfigMigrator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/migration/TableConfigMigrator.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+import org.apache.pinot.spi.config.table.TableConfig;
+
+
+/// A [ConfigMigrator] that upgrades a [TableConfig] from one migration version to the next.
+///
+/// Register concrete implementations with [ConfigMigrationRegistry#registerTableConfigMigrator] so
+/// they participate in the startup migration chain run by the controller.
+public interface TableConfigMigrator extends ConfigMigrator<TableConfig> {
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -77,6 +77,12 @@ public final class Schema implements Serializable {
   @Nullable
   private List<String> _tags;
   private boolean _enableColumnBasedNullHandling;
+  // Highest config-migration version applied to this schema by the controller's startup migration
+  // chain (see org.apache.pinot.spi.config.migration). 0 means "written before the migration
+  // framework existed". This is migration bookkeeping, not part of the schema's logical identity, so
+  // it is intentionally excluded from equals()/hashCode(). Older controllers ignore the JSON field
+  // via @JsonIgnoreProperties(ignoreUnknown = true), keeping rollback safe.
+  private int _configMigrationVersion;
   private final List<DimensionFieldSpec> _dimensionFieldSpecs = new ArrayList<>();
   private final List<MetricFieldSpec> _metricFieldSpecs = new ArrayList<>();
   @SuppressWarnings("deprecation")
@@ -206,6 +212,16 @@ public final class Schema implements Serializable {
 
   public void setEnableColumnBasedNullHandling(boolean enableColumnBasedNullHandling) {
     _enableColumnBasedNullHandling = enableColumnBasedNullHandling;
+  }
+
+  /// The highest config-migration version applied to this schema. See
+  /// [org.apache.pinot.spi.config.migration.ConfigMigrationUtils] for how this marker is used.
+  public int getConfigMigrationVersion() {
+    return _configMigrationVersion;
+  }
+
+  public void setConfigMigrationVersion(int configMigrationVersion) {
+    _configMigrationVersion = configMigrationVersion;
   }
 
   @Nullable
@@ -407,6 +423,7 @@ public final class Schema implements Serializable {
     newSchema.setDescription(_description);
     newSchema.setTags(_tags);
     newSchema.setEnableColumnBasedNullHandling(isEnableColumnBasedNullHandling());
+    newSchema.setConfigMigrationVersion(_configMigrationVersion);
     List<String> primaryKeyColumns = getPrimaryKeyColumns();
     if (primaryKeyColumns != null) {
       newSchema.setPrimaryKeyColumns(primaryKeyColumns.stream()
@@ -531,6 +548,11 @@ public final class Schema implements Serializable {
       jsonObject.set("tags", tagsArray);
     }
     jsonObject.set("enableColumnBasedNullHandling", JsonUtils.objectToJsonNode(_enableColumnBasedNullHandling));
+    // Only emit the migration marker once it has advanced past the initial version, so schemas that
+    // predate the migration framework keep serializing to identical JSON.
+    if (_configMigrationVersion != 0) {
+      jsonObject.put("configMigrationVersion", _configMigrationVersion);
+    }
     if (!_dimensionFieldSpecs.isEmpty()) {
       ArrayNode jsonArray = JsonUtils.newArrayNode();
       for (DimensionFieldSpec dimensionFieldSpec : _dimensionFieldSpecs) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/migration/ConfigMigrationRegistryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/migration/ConfigMigrationRegistryTest.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.migration;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableCustomConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+public class ConfigMigrationRegistryTest {
+
+  private static TableConfig newTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+  }
+
+  private static Schema newSchema() {
+    Schema schema = new Schema();
+    schema.setSchemaName("myTable");
+    schema.addField(new DimensionFieldSpec("d", DataType.STRING, true));
+    return schema;
+  }
+
+  /// A schema migrator that records the version it saw and bumps a counter in the schema description so we can assert
+  /// migrators run in order.
+  private static class RecordingSchemaMigrator implements SchemaMigrator {
+    private final int _fromVersion;
+    private final List<Integer> _log;
+
+    RecordingSchemaMigrator(int fromVersion, List<Integer> log) {
+      _fromVersion = fromVersion;
+      _log = log;
+    }
+
+    @Override
+    public int fromVersion() {
+      return _fromVersion;
+    }
+
+    @Override
+    public Schema migrate(Schema input) {
+      _log.add(_fromVersion);
+      return input;
+    }
+  }
+
+  @Test
+  public void testEmptyRegistryIsIdentity() {
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    assertEquals(registry.getCurrentTableConfigVersion(), 0);
+    assertEquals(registry.getCurrentSchemaVersion(), 0);
+
+    TableConfig tableConfig = newTableConfig();
+    MigrationResult<TableConfig> result = registry.migrateTableConfig(tableConfig);
+    assertFalse(result.isChanged());
+    assertSame(result.getConfig(), tableConfig);
+    assertEquals(result.getVersion(), 0);
+  }
+
+  @Test
+  public void testMigratorsRunInOrderFromStoredVersion() {
+    List<Integer> log = new ArrayList<>();
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    registry.registerSchemaMigrator(new RecordingSchemaMigrator(0, log));
+    registry.registerSchemaMigrator(new RecordingSchemaMigrator(1, log));
+    registry.registerSchemaMigrator(new RecordingSchemaMigrator(2, log));
+    assertEquals(registry.getCurrentSchemaVersion(), 3);
+
+    // A version-0 schema runs all three migrators in order.
+    Schema schema = newSchema();
+    MigrationResult<Schema> result = registry.migrateSchema(schema);
+    assertTrue(result.isChanged());
+    assertEquals(result.getVersion(), 3);
+    assertEquals(ConfigMigrationUtils.getSchemaVersion(result.getConfig()), 3);
+    assertEquals(log, List.of(0, 1, 2));
+
+    // A schema already at version 2 only runs the last migrator.
+    log.clear();
+    Schema partiallyMigrated = newSchema();
+    partiallyMigrated.setConfigMigrationVersion(2);
+    MigrationResult<Schema> result2 = registry.migrateSchema(partiallyMigrated);
+    assertTrue(result2.isChanged());
+    assertEquals(result2.getVersion(), 3);
+    assertEquals(log, List.of(2));
+  }
+
+  @Test
+  public void testAlreadyCurrentIsNoOp() {
+    List<Integer> log = new ArrayList<>();
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    registry.registerSchemaMigrator(new RecordingSchemaMigrator(0, log));
+
+    Schema schema = newSchema();
+    schema.setConfigMigrationVersion(1);
+    MigrationResult<Schema> result = registry.migrateSchema(schema);
+    assertFalse(result.isChanged());
+    assertSame(result.getConfig(), schema);
+    assertEquals(result.getVersion(), 1);
+    assertTrue(log.isEmpty());
+  }
+
+  @Test
+  public void testStoredVersionAboveCurrentIsUntouched() {
+    // e.g. after a controller downgrade: a config stamped at a higher version must not be "migrated" backwards.
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    registry.registerSchemaMigrator(new RecordingSchemaMigrator(0, new ArrayList<>()));
+
+    Schema schema = newSchema();
+    schema.setConfigMigrationVersion(5);
+    MigrationResult<Schema> result = registry.migrateSchema(schema);
+    assertFalse(result.isChanged());
+    assertEquals(ConfigMigrationUtils.getSchemaVersion(result.getConfig()), 5);
+  }
+
+  @Test
+  public void testRegistrationEnforcesDenseAscendingOrder() {
+    ConfigMigrationRegistry registry = new ConfigMigrationRegistry();
+    // First migrator must declare fromVersion == 0.
+    assertThrows(IllegalArgumentException.class,
+        () -> registry.registerSchemaMigrator(new RecordingSchemaMigrator(1, new ArrayList<>())));
+
+    registry.registerSchemaMigrator(new RecordingSchemaMigrator(0, new ArrayList<>()));
+    // Next migrator must declare fromVersion == 1, not skip to 2.
+    assertThrows(IllegalArgumentException.class,
+        () -> registry.registerSchemaMigrator(new RecordingSchemaMigrator(2, new ArrayList<>())));
+  }
+
+  @Test
+  public void testTableConfigMarkerRoundTrip()
+      throws Exception {
+    // Start with a pre-existing user custom config that must be preserved when the marker is stamped.
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable")
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of("userKey", "userValue"))))
+        .build();
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(tableConfig), 0);
+
+    ConfigMigrationUtils.setTableConfigVersion(tableConfig, 3);
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(tableConfig), 3);
+    // Stamping the marker preserves the user's existing custom config.
+    assertEquals(tableConfig.getCustomConfig().getCustomConfigs().get("userKey"), "userValue");
+    assertEquals(tableConfig.getCustomConfig().getCustomConfigs().get(ConfigMigrationUtils.MIGRATION_VERSION_KEY), "3");
+
+    // The marker (and the user config) survive a full JSON round-trip.
+    TableConfig deserialized = JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class);
+    assertEquals(ConfigMigrationUtils.getTableConfigVersion(deserialized), 3);
+    assertEquals(deserialized.getCustomConfig().getCustomConfigs().get("userKey"), "userValue");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaTest.java
@@ -841,4 +841,37 @@ public class SchemaTest {
     ComplexFieldSpec cfs = (ComplexFieldSpec) fs;
     Assert.assertEquals(cfs.getChildFieldSpec("count").getDataType(), FieldSpec.DataType.INT);
   }
+
+  @Test
+  public void testConfigMigrationVersionMarker()
+      throws Exception {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("test")
+        .addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
+        .build();
+    // Default marker is 0 and is not emitted, so schemas that predate the framework serialize unchanged.
+    Assert.assertEquals(schema.getConfigMigrationVersion(), 0);
+    Assert.assertFalse(schema.toJsonObject().has("configMigrationVersion"));
+
+    schema.setConfigMigrationVersion(2);
+    Assert.assertTrue(schema.toJsonObject().has("configMigrationVersion"));
+
+    // The marker survives a JSON round-trip.
+    Schema deserialized = JsonUtils.stringToObject(JsonUtils.objectToString(schema), Schema.class);
+    Assert.assertEquals(deserialized.getConfigMigrationVersion(), 2);
+
+    // Backward/forward compatibility: JSON carrying the marker plus an unknown future field still deserializes
+    // (older readers ignore both via @JsonIgnoreProperties(ignoreUnknown = true)).
+    String json = "{\"schemaName\":\"test\",\"configMigrationVersion\":4,\"someFutureField\":\"x\","
+        + "\"dimensionFieldSpecs\":[{\"name\":\"svDimension\",\"dataType\":\"INT\"}]}";
+    Schema fromFutureJson = JsonUtils.stringToObject(json, Schema.class);
+    Assert.assertEquals(fromFutureJson.getConfigMigrationVersion(), 4);
+
+    // The marker is bookkeeping, not identity: two schemas differing only by marker are equal.
+    Schema other = new Schema.SchemaBuilder().setSchemaName("test")
+        .addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
+        .build();
+    other.setConfigMigrationVersion(5);
+    Assert.assertEquals(schema, other);
+    Assert.assertEquals(schema.hashCode(), other.hashCode());
+  }
 }


### PR DESCRIPTION
## Summary

Adds a **versioned config-migration framework** that transparently upgrades stored `TableConfig`s and `Schema`s to the current version on the controller, so cluster upgrades don't surprise users with configs the new controller can no longer parse or validate.

The migration runs as a leader-only controller periodic task. For every table it reads the config *exactly as stored*, runs an ordered migrator chain, and — only if something changed — persists the result through the standard `PinotHelixResourceManager` write path (version-checked write **plus broker/server cache-refresh messages**). It's idempotent: once everything is current, runs are cheap no-ops.

## What's included

- **`pinot-spi`** — new `org.apache.pinot.spi.config.migration` package: `ConfigMigrator` / `TableConfigMigrator` / `SchemaMigrator`, `ConfigMigrationRegistry` (dense ordered chain), `MigrationResult`, `ConfigMigrationUtils`. Version markers are **rollback-safe**: `Schema` gains a `configMigrationVersion` field (older readers ignore it via `@JsonIgnoreProperties`), `TableConfig` uses a controller-managed `config.migration.version` custom-config key.
- **`pinot-segment-local`** — first concrete migrator (**v0 → v1**) folds deprecated ingestion fields (`tableIndexConfig.streamConfigs`, `segmentsConfig.segmentPushType`/`segmentPushFrequency`) into `ingestionConfig`, finally wiring the previously test-only `TableConfigUtils.convertFromLegacyTableConfig` into a live path. Schema chain ships empty (framework ready; no placeholder transforms).
- **`pinot-controller`** — `ConfigMigrationManager` periodic task + wiring in `BaseControllerStarter`; config keys in `ControllerConf`; `CONFIG_MIGRATION_SUCCESS`/`CONFIG_MIGRATION_FAILURE` meters.
- **`pinot-common`** — fixes `toTableConfig` to preserve env-var substitution when `applyDecorator=false`; adds a raw-read `getTableConfigWithVersion` overload.

## Configuration

| Key | Default | Notes |
|---|---|---|
| `controller.config.migration.enabled` | `true` | Set `false` to opt out |
| `controller.config.migration.frequencyPeriod` | `1h` | |
| `controller.config.migration.initialDelaySeconds` | randomized | |
| `controller.config.migration.cronExpression` | (none) | |

## Safety / compatibility

- **Optimistic concurrency:** version-checked writes never clobber a concurrent operator edit — a lost race is skipped and retried next cycle.
- **Validate before persist:** a buggy migrator can never write an invalid config; a not-yet-created schema is treated as transient (skip, no failure metric).
- **Rollback-safe:** an older controller ignores the new marker field/key; JSON with the marker + unknown future fields still deserializes.
- **Cache convergence:** writes go through the standard RM path so broker/server in-memory caches refresh.

## Tests

- **Deprecated → new upgrade** (`pinot-segment-local`): stream-only, batch-only, and combined deprecated configs fold into `ingestionConfig`; deprecated fields cleared; marker stamped; survives a ZK ZNRecord serialization round-trip; already-migrated config is a no-op.
- **Registry/markers** (`pinot-spi`): in-order chain, version-compare skip, downgrade left untouched, dense-ordering enforced, TableConfig marker JSON round-trip (preserving user custom configs), Schema marker round-trip + unknown-property tolerance.
- **Controller task**: persist-through-RM with version check + success metric, already-current not written, missing-schema skip, persist-failure caught + metered, schema migrated once across hybrid halves.

All precommit checks pass (spotless, license, checkstyle: 0 violations) across the four touched modules.

## Notes for reviewers

- Enabled **by default** and rewrites stored configs cluster-wide on first upgrade — please confirm this warrants a **release note** and docs for the new `controller.config.migration.*` keys.
- Adds a **new public SPI package** and a new `Schema` field — flagging for plugin-maintaining teams (additive, rollback-safe).